### PR TITLE
Allow the user to disable scaling on GASF and GADF images

### DIFF
--- a/pyts/image/image.py
+++ b/pyts/image/image.py
@@ -37,8 +37,8 @@ class GASF(BaseEstimator, TransformerMixin):
         overlapping windows.
 
     scale : {-1, 0, None} (default = -1)
-        The lower bound of the scaled time series.
-        If scale is None, the time series will not be scaled.
+        The lower bound of the scaled time series. If None, the time series
+        will not be scaled.
 
     """
 
@@ -100,6 +100,10 @@ class GASF(BaseEstimator, TransformerMixin):
             scaler = MinMaxScaler(feature_range=(self.scale, 1))
             X_scaled = scaler.fit_transform(X_paa.T).T
         else:
+            X_min, X_max = np.min(X), np.max(X)
+            if (X_min < -1) or (X_max > 1):
+                raise ValueError("If 'scaling=None', all the values of X "
+                                 "must be between -1 and 1".)
             X_scaled = X_paa
         X_sin = np.sqrt(np.clip(1 - X_scaled**2, 0, 1))
         X_scaled_outer = np.apply_along_axis(self._outer, 1, X_scaled)
@@ -123,8 +127,8 @@ class GADF(BaseEstimator, TransformerMixin):
         done with possible overlapping windows.
 
     scale : {-1, 0, None} (default = -1)
-        The lower bound of the scaled time series.
-        If scale is None, the time series will not be scaled.
+        The lower bound of the scaled time series. If None, the time series
+        will not be scaled.
 
     """
 
@@ -186,6 +190,10 @@ class GADF(BaseEstimator, TransformerMixin):
             scaler = MinMaxScaler(feature_range=(self.scale, 1))
             X_scaled = scaler.fit_transform(X_paa.T).T
         else:
+            X_min, X_max = np.min(X), np.max(X)
+            if (X_min < -1) or (X_max > 1):
+                raise ValueError("If 'scaling=None', all the values of X "
+                                 "must be between -1 and 1".)
             X_scaled = X_paa
         X_sin = np.sqrt(np.clip(1 - X_scaled**2, 0, 1))
         X_scaled_sin = np.hstack([X_scaled, X_sin])

--- a/pyts/image/image.py
+++ b/pyts/image/image.py
@@ -36,8 +36,8 @@ class GASF(BaseEstimator, TransformerMixin):
         If True, reduce the size of each time series using PAA with possible
         overlapping windows.
 
-    scale : {-1, 0} (default = -1)
-        The lower bound of the scaled time series.
+    scale : {-1, 0, None} (default = -1)
+        The lower bound of the scaled time series. If scale is None, the time series will not be scaled.
 
     """
 
@@ -90,13 +90,16 @@ class GASF(BaseEstimator, TransformerMixin):
                              "the size of each time series.")
         if not isinstance(self.overlapping, (float, int)):
             raise TypeError("'overlapping' must be a boolean.")
-        if self.scale not in [0, -1]:
-            raise ValueError("'scale' must be either 0 or -1.")
+        if self.scale not in [0, -1, None]:
+            raise ValueError("'scale' must be either 0, -1, or None.")
 
         paa = PAA(output_size=self.image_size, overlapping=self.overlapping)
         X_paa = paa.fit_transform(X)
-        scaler = MinMaxScaler(feature_range=(self.scale, 1))
-        X_scaled = scaler.fit_transform(X_paa.T).T
+        if self.scale is not None:
+            scaler = MinMaxScaler(feature_range=(self.scale, 1))
+            X_scaled = scaler.fit_transform(X_paa.T).T
+        else:
+            X_scaled = X_paa
         X_sin = np.sqrt(np.clip(1 - X_scaled**2, 0, 1))
         X_scaled_outer = np.apply_along_axis(self._outer, 1, X_scaled)
         X_sin_outer = np.apply_along_axis(self._outer, 1, X_sin)
@@ -118,8 +121,8 @@ class GADF(BaseEstimator, TransformerMixin):
         If True, reducing the size of the time series with PAA is
         done with possible overlapping windows.
 
-    scale : {-1, 0} (default = -1)
-        The lower bound of the scaled time series.
+    scale : {-1, 0, None} (default = -1)
+        The lower bound of the scaled time series. If scale is None, the time series will not be scaled.
 
     """
 
@@ -171,14 +174,17 @@ class GADF(BaseEstimator, TransformerMixin):
                              "the size of each time series.")
         if not isinstance(self.overlapping, (float, int)):
             raise TypeError("'overlapping' must be a boolean.")
-        if self.scale not in [0, -1]:
-            raise ValueError("'scale' must be either 0 or -1.")
+        if self.scale not in [0, -1, None]:
+            raise ValueError("'scale' must be either 0, -1, or None.")
 
         paa = PAA(output_size=self.image_size, overlapping=self.overlapping)
         X_paa = paa.fit_transform(X)
         n_features_new = X_paa.shape[1]
-        scaler = MinMaxScaler(feature_range=(self.scale, 1))
-        X_scaled = scaler.fit_transform(X_paa.T).T
+        if self.scale is not None:
+            scaler = MinMaxScaler(feature_range=(self.scale, 1))
+            X_scaled = scaler.fit_transform(X_paa.T).T
+        else:
+            X_scaled = X_paa
         X_sin = np.sqrt(np.clip(1 - X_scaled**2, 0, 1))
         X_scaled_sin = np.hstack([X_scaled, X_sin])
         X_scaled_sin_outer = np.apply_along_axis(self._outer_stacked,

--- a/pyts/image/image.py
+++ b/pyts/image/image.py
@@ -37,7 +37,8 @@ class GASF(BaseEstimator, TransformerMixin):
         overlapping windows.
 
     scale : {-1, 0, None} (default = -1)
-        The lower bound of the scaled time series. If scale is None, the time series will not be scaled.
+        The lower bound of the scaled time series.
+        If scale is None, the time series will not be scaled.
 
     """
 
@@ -122,7 +123,8 @@ class GADF(BaseEstimator, TransformerMixin):
         done with possible overlapping windows.
 
     scale : {-1, 0, None} (default = -1)
-        The lower bound of the scaled time series. If scale is None, the time series will not be scaled.
+        The lower bound of the scaled time series.
+        If scale is None, the time series will not be scaled.
 
     """
 


### PR DESCRIPTION
The normalization step when generating the compound images is really useful. However, if the time series data being turned into a compound image is an observation of a longer series of data with a larger range of values, the normalization removes valuable information.

I'm part of a research team at Queen's University and we are using your library to predict who will experience delirium in the ICU. While developing our model we realized the normalization step made it impossible for the model to learn. To give a practical example, one of the features we have is a patient's heart rate. One patient may have a peak heart rate of 200 whereas another one may have a peak heart rate of 140. The normalization treats both peak values as 1 because the smaller values belongs to a different patient and a different training case. To resolve this we, normalize the data across all the patients before creating the compound images without the normalization step. This way, the GASF and GADF have values within a limited range as required, but we keep information regarding what observations are greater than others to keep the observation in context.