### PR TITLE
Lower bounds for Dynamic Time Warping

### DIFF
--- a/pyts/metrics/__init__.py
+++ b/pyts/metrics/__init__.py
@@ -4,7 +4,12 @@ from .boss import boss
 from .dtw import (dtw_classic, dtw_region, dtw_sakoechiba, dtw_itakura,
                   dtw_multiscale, dtw_fast, dtw, itakura_parallelogram,
                   sakoe_chiba_band, show_options)
+from .lower_bounds import (lower_bound_improved, lower_bound_keogh,
+                           lower_bound_kim, lower_bound_yi)
+
 
 __all__ = ['boss', 'dtw_classic', 'dtw_region', 'dtw_sakoechiba',
            'dtw_itakura', 'dtw_multiscale', 'dtw_fast', 'dtw',
-           'itakura_parallelogram', 'sakoe_chiba_band', 'show_options']
+           'itakura_parallelogram', 'lower_bound_improved',
+           'lower_bound_keogh', 'lower_bound_kim', 'lower_bound_yi',
+           'sakoe_chiba_band', 'show_options']

--- a/pyts/metrics/lower_bounds.py
+++ b/pyts/metrics/lower_bounds.py
@@ -77,9 +77,9 @@ def lower_bound_yi(X_train, X_test):
 
     References
     ----------
-    .. [1] B. K. Yi et al, "Efficient Retrieval of Similar Time
-           Sequences Under Time Warping". International Conference on
-           Data Engineering, 201-208 (1998).
+    .. [1] B. K. Yi et al, "Efficient Retrieval of Similar Time Sequences
+           Under Time Warping". International Conference on Data Engineering,
+           201-208 (1998).
 
     Examples
     --------
@@ -119,10 +119,9 @@ def lower_bound_kim(X_train, X_test):
 
     References
     ----------
-    .. [1] S. W. Kim et al, "An Index-Based Approach
-           for Similarity Search Supporting Time Warping in Large
-           Sequence Databases". International Conference on Data
-           Engineering, 607-614 (2001).
+    .. [1] S. W. Kim et al, "An Index-Based Approach for Similarity Search
+           Supporting Time Warping in Large Sequence Databases". International
+           Conference on Data Engineering, 607-614 (2001).
 
     Examples
     --------

--- a/pyts/metrics/lower_bounds.py
+++ b/pyts/metrics/lower_bounds.py
@@ -1,0 +1,403 @@
+"""Code for Lower Bounds of Dynamic Time Warping."""
+
+# Author: Johann Faouzi <johann.faouzi@gmail.com>
+# License: BSD-3-Clause
+
+import numpy as np
+from math import sqrt
+from numba import njit, prange
+from sklearn.utils import check_array
+
+
+def _check_consistent_lengths(X, Y):
+    n_timestamps_X, n_timestamps_Y = X.shape[-1], Y.shape[-1]
+    if not n_timestamps_X == n_timestamps_Y:
+        raise ValueError(
+            "Found input variables with inconsistent numbers of "
+            "timestamps: [{0}, {1}]".format(n_timestamps_X, n_timestamps_Y)
+        )
+
+
+@njit()
+def _lower_bound_yi_x_y(x, x_min, x_max, y, y_min, y_max):
+    if x_max >= y_max:
+        if x_min < y_min:
+            sum1 = np.sum(np.square(x[x > y_max] - y_max))
+            sum2 = np.sum(np.square(x[x < y_min] - y_min))
+            return sqrt(sum1 + sum2)
+        elif x_min > y_max:
+            return sqrt(max(np.sum(np.square(x - y_max)),
+                            np.sum(np.square(y - x_min))))
+        else:
+            sum1 = np.sum(np.square(x[x > y_max] - y_max))
+            sum2 = np.sum(np.square(y[y < x_min] - x_min))
+            return sqrt(sum1 + sum2)
+    else:
+        if y_min < x_min:
+            sum1 = np.sum(np.square(y[y > x_max] - x_max))
+            sum2 = np.sum(np.square(y[y < x_min] - x_min))
+            return sqrt(sum1 + sum2)
+        elif y_min > x_max:
+            return sqrt(max(np.sum(np.square(y - x_max)),
+                            np.sum(np.square(x - y_min))))
+        else:
+            sum1 = np.sum(np.square(y[y > x_max] - x_max))
+            sum2 = np.sum(np.square(x[x < y_min] - y_min))
+            return sqrt(sum1 + sum2)
+
+
+@njit()
+def _lower_bound_yi_X_Y(X, X_min, X_max, Y, Y_min, Y_max):
+    n_samples_X, _ = X.shape
+    n_samples_Y, _ = Y.shape
+    X_yi = np.empty((n_samples_X, n_samples_Y))
+    for i in prange(n_samples_X):
+        for j in prange(n_samples_Y):
+            X_yi[i, j] = _lower_bound_yi_x_y(
+                X[i], X_min[i], X_max[i], Y[j], Y_min[j], Y_max[j]
+            )
+    return X_yi
+
+
+def lower_bound_yi(X_train, X_test):
+    """Compute the "LB_Yi" lower bounds between two datasets.
+
+    Parameters
+    ----------
+    X_train : array-like, shape = (n_samples_train, n_timestamps)
+        Training set.
+
+    X_test: : array-like, shape = (n_samples_test, n_timestamps)
+        Test set.
+
+    Returns
+    -------
+    lower_bounds : array, shape = (n_samples_test, n_samples_train)
+        "LB_Yi" lower bounds.
+
+    References
+    ----------
+    .. [1] B. K. Yi et al, "Efficient Retrieval of Similar Time
+           Sequences Under Time Warping". International Conference on
+           Data Engineering, 201-208 (1998).
+
+    Examples
+    --------
+    >>> X_train = [[5, 4, 3, 2, 1], [1, 8, 4, 3, 2], [6, 3, 5, 4, 7]]
+    >>> X_test = [[2, 1, 8, 4, 5]]
+    >>> lower_bound_yi(X_train, X_test)
+    array([[3.        , 0.        , 2.44...]])
+
+    """
+    X_train = check_array(X_train)
+    X_test = check_array(X_test)
+    _check_consistent_lengths(X_train, X_test)
+    X_train_min = np.min(X_train, axis=1)
+    X_train_max = np.max(X_train, axis=1)
+    X_test_min = np.min(X_test, axis=1)
+    X_test_max = np.max(X_test, axis=1)
+    lb_yi = _lower_bound_yi_X_Y(X_test, X_test_min, X_test_max,
+                                X_train, X_train_min, X_train_max)
+    return lb_yi
+
+
+def lower_bound_kim(X_train, X_test):
+    """Compute the "LB_Kim" lower bounds between two datasets.
+
+    Parameters
+    ----------
+    X_train : array-like, shape = (n_samples_train, n_timestamps)
+        Training set.
+
+    X_test: : array-like, shape = (n_samples_test, n_timestamps)
+        Test set.
+
+    Returns
+    -------
+    lower_bounds : array, shape = (n_samples_test, n_samples_train)
+        "LB_Kim" lower bounds.
+
+    References
+    ----------
+    .. [1] S. W. Kim et al, "An Index-Based Approach
+           for Similarity Search Supporting Time Warping in Large
+           Sequence Databases". International Conference on Data
+           Engineering, 607-614 (2001).
+
+    Examples
+    --------
+    >>> X_train = [[2, 1, 8, 4, 5], [1, 2, 3, 4, 5]]
+    >>> X_test = [[5, 4, 3, 2, 1], [1, 8, 4, 3, 2], [6, 3, 5, 4, 7]]
+    >>> lower_bound_kim(X_train, X_test)
+    array([[4, 4],
+           [3, 3],
+           [4, 5]])
+
+    """
+    X_train = check_array(X_train)
+    X_test = check_array(X_test)
+    _check_consistent_lengths(X_train, X_test)
+    first = np.abs(X_test[:, 0, None] - X_train[None, :, 0])
+    last = np.abs(X_test[:, -1, None] - X_train[None, :, -1])
+    max_ = np.abs(np.max(X_test, axis=1)[:, None]
+                  - np.max(X_train, axis=1)[None, :])
+    min_ = np.abs(np.min(X_test, axis=1)[:, None]
+                  - np.min(X_train, axis=1)[None, :])
+    lb_kim = np.max(np.asarray([first, last, max_, min_]), axis=0)
+    return lb_kim
+
+
+@njit()
+def _warping_envelope_2d(X, n_samples, n_timestamps, region):
+    lower = np.empty((n_samples, n_timestamps))
+    upper = np.empty((n_samples, n_timestamps))
+    for i in prange(n_samples):
+        for j in prange(n_timestamps):
+            sub_series = X[i, region[0, j]:region[1, j]]
+            lower[i, j] = np.min(sub_series)
+            upper[i, j] = np.max(sub_series)
+    return lower, upper
+
+
+@njit()
+def _warping_envelope_3d(X, n_samples_X, n_samples_Y, n_timestamps, region):
+    lower = np.empty((n_samples_X, n_samples_Y, n_timestamps))
+    upper = np.empty((n_samples_X, n_samples_Y, n_timestamps))
+    for i in prange(n_samples_X):
+        for j in prange(n_samples_Y):
+            for k in prange(n_timestamps):
+                sub_series = X[i, j, region[0, k]:region[1, k]]
+                lower[i, j, k] = np.min(sub_series)
+                upper[i, j, k] = np.max(sub_series)
+    return lower, upper
+
+
+def _warping_envelope(X, region):
+    """Compute the warping envelope.
+
+    Parameters
+    ----------
+    X : array
+        Input data. It must be two- or three-dimensional.
+
+    region : array, shape = (2, n_timestamps)
+        Constraint region. The first row consists of the starting indices
+        (included) and the second row consists of the ending indices (excluded)
+        of the valid rows for each column.
+
+    Returns
+    -------
+    lower : array
+        The lower envelope.
+
+    upper : array
+        The upper envelope.
+
+    """
+    X = check_array(X, ensure_2d=False, allow_nd=True)
+    region = check_array(region, ensure_min_samples=2)
+    n_dims = X.ndim
+    if n_dims not in (2, 3):
+        raise ValueError("X must be a two- or three-dimensional.")
+    if n_dims == 2:
+        n_samples, n_timestamps = X.shape
+        lower, upper = _warping_envelope_2d(
+            X, n_samples, n_timestamps, region
+        )
+    else:
+        n_samples_X, n_samples_Y, n_timestamps = X.shape
+        lower, upper = _warping_envelope_3d(
+            X, n_samples_X, n_samples_Y, n_timestamps, region
+        )
+    return lower, upper
+
+
+@njit()
+def _clip_2d(X, X_min, X_max, n_samples_X, n_samples_clip, n_timestamps):
+    X_clipped = np.empty((n_samples_X, n_samples_clip, n_timestamps))
+    for i in prange(n_samples_X):
+        X_clipped[i] = np.minimum(np.maximum(X[i], X_min), X_max)
+    return X_clipped
+
+
+@njit()
+def _clip_3d(X, X_min, X_max, n_samples_X, n_samples_clip, n_timestamps):
+    X_clipped = np.empty((n_samples_X, n_samples_clip, n_timestamps))
+    for i in prange(n_samples_X):
+        X_clipped[i] = np.minimum(np.maximum(X[i], X_min[:, i]), X_max[:, i])
+    return X_clipped
+
+
+def _clip(X, lower, upper):
+    """Clip an array.
+
+    Parameters
+    ----------
+    X : array, shape = (n_samples, n_timestamps)
+        Array to clip.
+
+    lower : array
+        Minimum values in the clipped array. It must be
+        two- or three-dimensional.
+
+    upper : array
+        Maximum values in the clipped array. It must be
+        two- or three-dimensional, and have the same shape
+        as ``lower``.
+
+    Returns
+    -------
+    X_clipped : array
+        Clipped array.
+
+    """
+    X = check_array(X)
+    lower = check_array(lower, ensure_2d=False, allow_nd=True)
+    upper = check_array(upper, ensure_2d=False, allow_nd=True)
+    n_dims = lower.ndim
+    if n_dims not in (2, 3):
+        raise ValueError("'lower' must be two- or three-dimensional.")
+    if not lower.shape == upper.shape:
+        raise ValueError(
+            "'lower' and 'upper' must have the same shape "
+            "({0} != {1})".format(lower.shape, upper.shape)
+        )
+    if n_dims == 2:
+        n_samples_X, n_timestamps = X.shape
+        n_samples_clip, _ = lower.shape
+        X_clipped = _clip_2d(
+            X, lower, upper, n_samples_X, n_samples_clip, n_timestamps
+        )
+    else:
+        n_samples_X, n_samples_Y, n_timestamps = lower.shape
+        X_clipped = _clip_3d(
+            X, lower, upper, n_samples_Y, n_samples_X, n_timestamps
+        )
+    return X_clipped
+
+
+def lower_bound_keogh(X_train, X_test, region):
+    r"""Compute the "LB_Keogh" lower bounds between two datasets.
+
+    Parameters
+    ----------
+    X_train : array-like, shape = (n_samples_train, n_timestamps)
+        Training set. The warping envelopes are computed
+        on this set.
+
+    X_test: : array-like, shape = (n_samples_test, n_timestamps)
+        Test set.
+
+    region : array, shape = (2, n_timestamps)
+        Constraint region. The first row consists of the starting indices
+        (included) and the second row consists of the ending indices (excluded)
+        of the valid rows for each column.
+
+    Returns
+    -------
+    lower_bounds : array, shape = (n_samples_test, n_samples_train)
+        "LB_Keogh" lower bounds.
+
+    Notes
+    -----
+    The "LB_Keogh" lower bounds are computed as
+
+    .. math:: LB_Keogh(X, Y) = \Vert X - H(X, Y) \Vert_{2}
+
+    where :math:`X` is the test set (``X_test``), :math:`Y` is the
+    training set (``X_train``), and :math:`H(X, Y)` is the projection
+    of :math:`X` on :math:`Y`.
+
+    References
+    ----------
+    .. [1] E. Keogh and C. A. Ratanamahatana, "Exact indexing of dynamic
+           time warping". Knowledge and Information Systems, 7(3),
+           358-386 (2005).
+
+    Examples
+    --------
+    >>> X_train = [[0, 1, 2, 3], [1, 2, 3, 4]]
+    >>> X_test = [[0, 2.5, 3.5, 6]]
+    >>> region = [[0, 0, 1, 2], [2, 3, 4, 4]]
+    >>> lower_bound_keogh(X_train, X_test, region)
+    array([[3.08...  , 2.23...]])
+
+    """
+    X_train = check_array(X_train)
+    X_test = check_array(X_test)
+    _check_consistent_lengths(X_train, X_test)
+    lower, upper = _warping_envelope(X_train, region)
+    X_proj = _clip(X_test, lower, upper)
+    squared_lb_keogh = np.sum(
+        (X_test[:, None, :] - X_proj) ** 2, axis=-1
+    )
+    return np.sqrt(squared_lb_keogh)
+
+
+def lower_bound_improved(X_train, X_test, region):
+    r"""Compute the "LB_Improved" lower bounds between two datasets.
+
+    Parameters
+    ----------
+    X_train : array-like, shape = (n_samples_train, n_timestamps)
+        Training set.
+
+    X_test: : array-like, shape = (n_samples_test, n_timestamps)
+        Test set.
+
+    region : array, shape = (2, n_timestamps)
+        Constraint region. The first row consists of the starting indices
+        (included) and the second row consists of the ending indices (excluded)
+        of the valid rows for each column.
+
+    Returns
+    -------
+    lower_bounds : array, shape = (n_samples_test, n_samples_train)
+        "LB_Improved" lower bounds.
+
+    Notes
+    -----
+    The "LB_Improved" lower bounds are computed as
+
+    .. math::
+
+        LB_Improved(X, Y) = \sqrt\left\( \Vert X - H(X, Y) \Vert_{2}^2
+        + \Vert Y - H(Y, H(X, Y)) \Vert_{2}^2 \right\)
+
+    where :math:`X` is the test set (``X_test``), :math:`Y` is the
+    training set (``X_train``), and :math:`H(X, Y)` is the projection
+    of :math:`X` on :math:`Y`.
+
+    References
+    ----------
+    .. [1] D. Lemire, "Faster Retrieval with a Two-Pass Dynamic-Time-Warping
+           Lower Bound". Pattern Recognition, 42(9), 2169-2180 (2009).
+
+    Examples
+    --------
+    >>> X_train = [[0, 1, 2, 3], [1, 2, 3, 4]]
+    >>> X_test = [[0, 2.5, 3.5, 3.3]]
+    >>> region = [[0, 0, 1, 2], [2, 3, 4, 4]]
+    >>> lower_bound_improved(X_train, X_test, region)
+    array([[0.76..., 1.11...]])
+
+    """
+    X_train = check_array(X_train)
+    X_test = check_array(X_test)
+    _check_consistent_lengths(X_train, X_test)
+
+    # LB Keogh lower bounds
+    lower_train, upper_train = _warping_envelope(X_train, region)
+    X_test_proj = _clip(X_test, lower_train, upper_train)
+    squared_lb_keogh = np.sum(
+        (X_test[:, None, :] - X_test_proj) ** 2, axis=-1
+    )
+
+    # LB Improved lower bounds
+    lower_test, upper_test = _warping_envelope(X_test_proj, region)
+    X_train_proj = _clip(X_train, lower_test, upper_test)
+    squared_lb_improved = np.sum(
+        (X_train[:, None, :] - X_train_proj) ** 2, axis=-1
+    )
+
+    return np.sqrt(squared_lb_keogh + squared_lb_improved.T)

--- a/pyts/metrics/tests/test_lower_bounds.py
+++ b/pyts/metrics/tests/test_lower_bounds.py
@@ -1,0 +1,241 @@
+"""Testing for Lower Bounds of Dynamic Time Warping."""
+
+import numpy as np
+import pytest
+import re
+from math import sqrt
+
+from pyts.metrics.lower_bounds import (
+    _lower_bound_yi_x_y, _lower_bound_yi_X_Y, _warping_envelope, _clip
+)
+from pyts.metrics import (lower_bound_improved, lower_bound_keogh,
+                          lower_bound_kim, lower_bound_yi)
+from pyts.metrics import dtw, dtw_sakoechiba, sakoe_chiba_band
+from sklearn.metrics import pairwise_distances
+
+
+@pytest.mark.parametrize(
+    'X, Y, err_msg',
+    [([[1, 1]], [[1]], "Found input variables with inconsistent numbers of "
+                       "timestamps: [2, 1]"),
+     ([[1]], [[1, 2]], "Found input variables with inconsistent numbers of "
+                       "timestamps: [1, 2]"),
+     ([[3, 1, 1]], [[1]], "Found input variables with inconsistent numbers of "
+                          "timestamps: [3, 1]")]
+)
+def test_check_consistent_lengths(X, Y, err_msg):
+    """Test 'lower_bound_yi' parameter validation."""
+    with pytest.raises(ValueError, match=re.escape(err_msg)):
+        lower_bound_yi(X, Y)
+
+
+@pytest.mark.parametrize(
+    'x, y, float_desired',
+    [([1, 5, 3, 2, 8], [3, 2, 5, 4, 5], sqrt(10)),
+     ([4, 5, 3, 6, 8], [1, 2, 0, 1, 2], sqrt(66)),
+     ([4, 5, 3, 6, 8], [1, 5, 3, 2, 1], sqrt(19)),
+     ([3, 2, 5, 4, 5], [1, 5, 3, 2, 8], sqrt(10)),
+     ([1, 2, 0, 1, 2], [4, 5, 3, 6, 8], sqrt(66)),
+     ([1, 5, 3, 2, 1], [4, 5, 3, 6, 8], sqrt(19))]
+)
+def test_lower_bound_yi_x_y(x, y, float_desired):
+    """Test '_lower_bound_yi_x_y' function."""
+    x, y = np.asarray(x), np.asarray(y)
+    float_actual = _lower_bound_yi_x_y(x, min(x), max(x), y, min(y), max(y))
+    np.testing.assert_allclose(float_actual, float_desired, atol=1e-5, rtol=0)
+
+
+@pytest.mark.parametrize(
+    'X, Y',
+    [([[3, 5, 1, 4, 6], [3, 8, 2, 4, 2]],
+      [[4, 5, 9, 2, 3], [4, 3, 5, 2, 3], [5, 9, 3, 3, 4]])]
+)
+def test_lower_bound_yi_X_Y(X, Y):
+    """Test '_lower_bound_yi_X_Y' function."""
+    X, Y = np.asarray(X), np.asarray(Y)
+    arr_actual = _lower_bound_yi_X_Y(X, X.min(axis=1), X.max(axis=1),
+                                     Y, Y.min(axis=1), Y.max(axis=1))
+    arr_desired = np.empty((2, 3))
+    for i in range(2):
+        for j in range(3):
+            arr_desired[i, j] = _lower_bound_yi_x_y(
+                X[i], X[i].min(), X[i].max(),
+                Y[j], Y[j].min(), Y[j].max()
+            )
+    np.testing.assert_allclose(arr_actual, arr_desired, atol=1e-5, rtol=0)
+
+
+@pytest.mark.parametrize(
+    'X_train, X_test, arr_desired',
+    [([[5, 4, 3, 2, 1], [1, 8, 4, 3, 2], [6, 3, 5, 4, 7]],
+      [[2, 1, 8, 4, 5]],
+      np.sqrt([[9, 0, 6]]))]
+)
+def test_actual_results_lower_bound_yi(X_train, X_test, arr_desired):
+    """Test that the actual results are the expected ones."""
+    arr_actual = lower_bound_yi(X_train, X_test)
+    np.testing.assert_allclose(arr_actual, arr_desired, atol=1e-5, rtol=0)
+
+
+@pytest.mark.parametrize(
+    'X_train, X_test, arr_desired',
+    [([[2, 1, 8, 4, 5], [1, 2, 3, 4, 5]],
+      [[5, 4, 3, 2, 1], [1, 8, 4, 3, 2], [6, 3, 5, 4, 7]],
+      [[4, 4], [3, 3], [4, 5]])]
+)
+def test_actual_results_lower_bound_kim(X_train, X_test, arr_desired):
+    """Test that the actual results are the expected ones."""
+    arr_actual = lower_bound_kim(X_train, X_test)
+    np.testing.assert_array_equal(arr_actual, arr_desired)
+
+
+@pytest.mark.parametrize(
+    'X, region, err_msg',
+    [([0, 1], [[0, 1], [0, 1]], "X must be a two- or three-dimensional."),
+     ([[[[0, 1, 2]]]], [[0, 1], [0, 1]],
+      "X must be a two- or three-dimensional.")]
+)
+def test_parameter_check_warping_envelope(X, region, err_msg):
+    """Test '_warping_envelope' parameter validation.."""
+    with pytest.raises(ValueError, match=err_msg):
+        _warping_envelope(X, region)
+
+
+@pytest.mark.parametrize(
+    'X, region, lower_desired, upper_desired',
+    [([[0, 1, 2, 3], [1, 5, 3, -1]], [[0, 0, 1, 2], [2, 3, 4, 4]],
+      [[0, 0, 1, 2], [1, 1, -1, -1]], [[1, 2, 3, 3], [5, 5, 5, 3]]),
+     ([[[0, 1, 2, 3], [1, 5, 3, -1]]], [[0, 0, 1, 2], [2, 3, 4, 4]],
+      [[[0, 0, 1, 2], [1, 1, -1, -1]]], [[[1, 2, 3, 3], [5, 5, 5, 3]]])]
+)
+def test_actual_results_warping_envelope(X, region,
+                                         lower_desired, upper_desired):
+    """Test that the actual results are the expected ones."""
+    lower_actual, upper_actual = _warping_envelope(X, region)
+    np.testing.assert_array_equal(lower_actual, lower_desired)
+    np.testing.assert_array_equal(upper_actual, upper_desired)
+
+
+@pytest.mark.parametrize(
+    'X, lower, upper, err_msg',
+    [([[0], [1]], [6], [[1], [1]],
+      "'lower' must be two- or three-dimensional."),
+     ([[0], [1]], [[[[6]]]], [[1], [1]],
+      "'lower' must be two- or three-dimensional."),
+     ([[0], [1]], [[[6]]], [[1], [1]],
+      "'lower' and 'upper' must have the same shape ((1, 1, 1) != (2, 1))")]
+)
+def test_parameter_check_clip(X, lower, upper, err_msg):
+    """Test '_clip' parameter validation.."""
+    with pytest.raises(ValueError, match=re.escape(err_msg)):
+        _clip(X, lower, upper)
+
+
+@pytest.mark.parametrize(
+    'X, lower, upper, arr_desired',
+    [([[0, 1, 2, 3], [1, 5, 3, -1]],
+      [[0, 3, 3, 3], [-1, 2, 4, 6]],
+      [[1, 5, 4, 6], [1, 3, 6, 8]],
+      [[[0, 3, 3, 3], [0, 2, 4, 6]], [[1, 5, 3, 3], [1, 3, 4, 6]]]),
+
+     ([[0, 1, 2, 3], [1, 5, 3, -1]],
+      [[[0, 3, 3, 3], [-1, 2, 4, 6]]],
+      [[[1, 5, 4, 6], [1, 3, 6, 8]]],
+      [[[0, 3, 3, 3]], [[1, 3, 4, 6]]])]
+)
+def test_actual_results_clip(X, lower, upper, arr_desired):
+    """Test that the actual results are the expected ones."""
+    arr_actual = _clip(X, lower, upper)
+    np.testing.assert_array_equal(arr_actual, arr_desired)
+
+
+def test_actual_results_lower_bound_keogh():
+    """Test that the actual results are the expected ones."""
+    # Toy dataset
+    X_train = np.asarray([[0, 1, 2, 3],
+                          [1, 2, 3, 4]])
+    X_test = np.asarray([[0, 2.5, 3.5, 6]])
+
+    # Region = Sakoe-Chiba band (w=0)
+    region = [[0, 1, 2, 3],
+              [1, 2, 3, 4]]
+    arr_actual = lower_bound_keogh(X_train, X_test, region)
+    arr_desired = np.sqrt(np.sum(
+        (X_test[:, None, :] - X_train[None, :, :]) ** 2, axis=-1
+    ))
+    np.testing.assert_allclose(arr_actual, arr_desired, atol=1e-5, rtol=0)
+
+    # Region = Sakoe-Chiba band (w=1)
+    region_window = [[0, 0, 1, 2],
+                     [2, 3, 4, 4]]
+    arr_actual_window = lower_bound_keogh(X_train, X_test, region_window)
+    # lower = [[0, 0, 1, 2], [1, 1, 2, 3]]
+    # upper = [[1, 2, 3, 3], [2, 3, 4, 4]]
+    # X_proj = [[0, 2, 3, 3], [1, 2.5, 3.5, 4]]
+    # LB_Keogh = [[sqrt(0.25 + 0.25 + 9), sqrt(1 + 4)]]
+    arr_desired_window = np.sqrt([[9.5, 5]])
+    np.testing.assert_allclose(arr_actual_window, arr_desired_window,
+                               atol=1e-5, rtol=0)
+
+
+def test_actual_results_lower_bound_improved():
+    """Test that the actual results are the expected ones."""
+    # Toy dataset
+    X_train = np.asarray([[0, 1, 2, 3],
+                          [1, 2, 3, 4]])
+    X_test = np.asarray([[0, 2.5, 3.5, 3.3]])
+
+    # Region = Sakoe-Chiba band (w=0)
+    region = [[0, 1, 2, 3],
+              [1, 2, 3, 4]]
+    arr_actual = lower_bound_improved(X_train, X_test, region)
+    arr_desired = np.sqrt(np.sum(
+        (X_test[:, None, :] - X_train[None, :, :]) ** 2, axis=-1
+    ))
+    np.testing.assert_allclose(arr_actual, arr_desired, atol=1e-5, rtol=0)
+
+    # Region = Sakoe-Chiba band (w=1)
+    region_window = [[0, 0, 1, 2],
+                     [2, 3, 4, 4]]
+    arr_actual_window = lower_bound_improved(X_train, X_test, region_window)
+    # lower_train = [[0, 0, 1, 2], [1, 1, 2, 3]
+    # upper_train = [[1, 2, 3, 3], [2, 3, 4, 4]]
+    # X_test_proj = [[0, 2, 3, 3], [1, 2.5, 3.5, 3.3]
+    # LB_Keogh^2 = [[0.25 + 0.25 + 0.09, 1]] = [[0.59, 1]]
+    # lower_test = [[0, 0, 2, 3], [1, 1, 2.5, 3.3]]
+    # upper_test = [[2, 3, 3, 3], [2.5, 3.5, 3.5, 3.5]]
+    # X_train_proj = [[0, 1, 2, 3], [1, 2, 3, 3.5]]
+    # LB_Improved^2 = [[0, 0.25]]
+    arr_desired_window = np.sqrt([[0.59 + 0, 1 + 0.25]])
+    np.testing.assert_allclose(arr_actual_window, arr_desired_window,
+                               atol=1e-5, rtol=0)
+
+
+def test_lower_bounds_inequalities():
+    """Test that the expected inequalities are verified."""
+    # Toy dataset
+    rng = np.random.RandomState(42)
+    n_samples_train, n_samples_test, n_timestamps = 20, 30, 60
+    window_size = 0.1
+    X_train = rng.randn(n_samples_train, n_timestamps)
+    X_test = rng.randn(n_samples_test, n_timestamps)
+
+    # DTW
+    X_dtw = pairwise_distances(X_test, X_train, dtw)
+    region = sakoe_chiba_band(n_timestamps, window_size=window_size)
+    X_dtw_window = pairwise_distances(X_test, X_train, dtw_sakoechiba,
+                                      window_size=window_size)
+
+    # Lower bounds
+    lb_yi = lower_bound_yi(X_train, X_test)
+    lb_kim = lower_bound_kim(X_train, X_test)
+    lb_keogh = lower_bound_keogh(X_train, X_test, region)
+    lb_improved = lower_bound_improved(X_train, X_test, region)
+
+    # Sanity check
+    EPS = 1e-8
+    np.testing.assert_array_less(lb_yi, X_dtw + EPS)
+    np.testing.assert_array_less(lb_kim, X_dtw + EPS)
+    np.testing.assert_array_less(lb_keogh, X_dtw_window + EPS)
+    np.testing.assert_array_less(lb_improved, X_dtw_window + EPS)
+    np.testing.assert_array_less(lb_keogh, lb_improved + EPS)


### PR DESCRIPTION
This PR adds computation of lower bounds for Dynamic Time Warping. Available lower bounds are:
* `lb_yi`
* `lb_kim`
* `lb_keogh`
* `lb_improved`