### PR TITLE
[MRG] Add "precomputed" option for dtw functions

### DIFF
--- a/examples/metrics/plot_dtw.py
+++ b/examples/metrics/plot_dtw.py
@@ -17,7 +17,7 @@ import matplotlib.pyplot as plt
 from pyts.datasets import load_gunpoint
 from pyts.metrics import dtw, itakura_parallelogram, sakoe_chiba_band
 from pyts.metrics.dtw import (cost_matrix, accumulated_cost_matrix,
-                              _return_path, _multiscale_region)
+                              _return_path, _blurred_path_region)
 
 # Parameters
 X, _, _, _ = load_gunpoint(return_X_y=True)
@@ -102,7 +102,7 @@ cost_mat_res = cost_matrix(x_padded, y_padded, dist='square', region=None)
 acc_cost_mat_res = accumulated_cost_matrix(cost_mat_res)
 path_res = _return_path(acc_cost_mat_res)
 
-multiscale_region = _multiscale_region(
+multiscale_region = _blurred_path_region(
     n_timestamps_1, n_timestamps_2, resolution, x_padded.size, y_padded.size,
     path_res,
     radius=radius

--- a/pyts/metrics/dtw.py
+++ b/pyts/metrics/dtw.py
@@ -343,17 +343,18 @@ def dtw_classic(x=None, y=None, dist='square', precomputed_cost=None,
     return res
 
 
-def dtw_region(x, y, dist='square', region=None, precomputed_cost=None,
-               return_cost=False, return_accumulated=False, return_path=False):
+def dtw_region(x=None, y=None, dist='square', region=None,
+               precomputed_cost=None, return_cost=False,
+               return_accumulated=False, return_path=False):
     """Dynamic Time Warping (DTW) distance with a constraint region.
 
     Parameters
     ----------
     x : array-like, shape = (n_timestamps_1,)
-        First array.
+        First array. Ignored if `dist` == "precomputed".
 
     y : array-like, shape = (n_timestamps_2,)
-        Second array
+        Second array.  Ignored if `dist` == "precomputed".
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.
@@ -515,18 +516,18 @@ def sakoe_chiba_band(n_timestamps_1, n_timestamps_2=None, window_size=0.1):
     return region
 
 
-def dtw_sakoechiba(x, y, dist='square', window_size=0.1, precomputed_cost=None,
-                   return_cost=False, return_accumulated=False,
-                   return_path=False):
+def dtw_sakoechiba(x=None, y=None, dist='square', window_size=0.1,
+                   precomputed_cost=None, return_cost=False,
+                   return_accumulated=False, return_path=False):
     """Dynamic Time Warping (DTW) distance with Sakoe-Chiba band constraint.
 
     Parameters
     ----------
     x : array-like, shape = (n_timestamps_1,)
-        First array.
+        First array. Ignored if `dist` == "precomputed".
 
     y : array-like, shape = (n_timestamps_2,)
-        Second array
+        Second array. Ignored if `dist` == "precomputed".
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.
@@ -691,18 +692,18 @@ def itakura_parallelogram(n_timestamps_1, n_timestamps_2=None, max_slope=2.):
     return region
 
 
-def dtw_itakura(x, y, dist='square', max_slope=2., precomputed_cost=None,
-                return_cost=False, return_accumulated=False,
-                return_path=False):
+def dtw_itakura(x=None, y=None, dist='square', max_slope=2.,
+                precomputed_cost=None, return_cost=False,
+                return_accumulated=False, return_path=False):
     """Dynamic Time Warping distance with Itakura parallelogram constraint.
 
     Parameters
     ----------
     x : array-like, shape (n_timestamps_1,)
-        First array.
+        First array. Ignored if `dist` == "precomputed".
 
     y : array-like, shape (n_timestamps_2,)
-        Second array
+        Second array. Ignored if `dist` == "precomputed".
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.
@@ -801,7 +802,7 @@ def _multiscale_region(n_timestamps_1, n_timestamps_2, resolution_level,
     return region.astype('int64')
 
 
-def dtw_multiscale(x, y, dist='square', resolution=2, radius=0,
+def dtw_multiscale(x=None, y=None, dist='square', resolution=2, radius=0,
                    precomputed_cost=None, return_cost=False,
                    return_accumulated=False, return_path=False):
     """Multiscale Dynamic Time Warping distance.
@@ -809,10 +810,10 @@ def dtw_multiscale(x, y, dist='square', resolution=2, radius=0,
     Parameters
     ----------
     x : array-like, shape = (n_timestamps_1,)
-        First array.
+        First array. Ignored if `dist` == "precomputed".
 
     y : array-like, shape = (n_timestamps_2,)
-        Second array
+        Second array. Ignored if `dist` == "precomputed".
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.

--- a/pyts/metrics/dtw.py
+++ b/pyts/metrics/dtw.py
@@ -979,6 +979,7 @@ def dtw_fast(x, y, dist='square', radius=0, precomputed_cost=None,
 
     """
     n_timestamps_1, n_timestamps_2 = _get_dimensions(x, y, dist,
+                                                     precomputed_cost)
     if not isinstance(radius, (int, np.integer)):
         raise TypeError("'radius' must be an integer.")
     if radius < 0:

--- a/pyts/metrics/dtw.py
+++ b/pyts/metrics/dtw.py
@@ -933,8 +933,8 @@ def _compute_region(n_timestamps_1, n_timestamps_2, method, dist,
 @deprecated("``dtw_multiscale`` is deprecated in v0.10 and will be removed "
             "in v0.11. Use ``dtw`` with ``method == 'multiscale'`` instead.")
 def dtw_multiscale(x, y, dist='square', resolution=2, radius=0,
-                   precomputed_cost=None, return_cost=False,
-                   return_accumulated=False, return_path=False):
+                   return_cost=False, return_accumulated=False,
+                   return_path=False):
     """Multiscale Dynamic Time Warping distance.
 
     Parameters
@@ -959,10 +959,6 @@ def dtw_multiscale(x, y, dist='square', resolution=2, radius=0,
         computed at the resolution level is expanded with `radius` cells to the
         top, bottom, left and right of every cell belonging to the optimal
         path. It is computed at the resolution level.
-
-    precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored if ``dist != 'precomputed'``.
-        Precomputed cost matrix between the time series.
 
     return_cost : bool (default = False)
         If True, the cost matrix is returned.
@@ -1000,7 +996,8 @@ def dtw_multiscale(x, y, dist='square', resolution=2, radius=0,
 
     """
     x, y, precomputed_cost, n_timestamps_1, n_timestamps_2 = \
-        _check_input_dtw(x, y, precomputed_cost, dist, method="multiscale")
+        _check_input_dtw(x, y, precomputed_cost=None, dist=dist,
+                         method="multiscale")
 
     region = _multiscale_region(x, y, dist, resolution=resolution,
                                 radius=radius)
@@ -1017,8 +1014,8 @@ def dtw_multiscale(x, y, dist='square', resolution=2, radius=0,
 
 @deprecated("``dtw_fast`` is deprecated in v0.10 and will be removed in "
             "v0.11. Use ``dtw`` with ``method == 'fast'`` instead.")
-def dtw_fast(x=None, y=None, dist='square', radius=0, precomputed_cost=None,
-             return_cost=False, return_accumulated=False, return_path=False):
+def dtw_fast(x=None, y=None, dist='square', radius=0, return_cost=False,
+             return_accumulated=False, return_path=False):
     """Fast Dynamic Time Warping distance.
 
     Parameters
@@ -1041,10 +1038,6 @@ def dtw_fast(x=None, y=None, dist='square', radius=0, precomputed_cost=None,
         computed at the resolution level is expanded with `radius` cells to the
         top, bottom, left and right of every cell belonging to the optimal
         path. It is computed at the resolution level.
-
-    precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored if ``dist != 'precomputed'``.
-        Precomputed cost matrix between the time series.
 
     return_cost : bool (default = False)
         If True, the cost matrix is returned.
@@ -1082,7 +1075,7 @@ def dtw_fast(x=None, y=None, dist='square', radius=0, precomputed_cost=None,
 
     """
     x, y, precomputed_cost, n_timestamps_1, n_timestamps_2 = \
-        _check_input_dtw(x, y, precomputed_cost, dist, method="fast")
+        _check_input_dtw(x, y, precomputed_cost=None, dist=dist, method="fast")
     region = _fast_region(x, y, dist, radius=radius)
     cost_mat = cost_matrix(x, y, dist=dist, region=region)
     acc_cost_mat = accumulated_cost_matrix(cost_mat, region=region)

--- a/pyts/metrics/dtw.py
+++ b/pyts/metrics/dtw.py
@@ -61,7 +61,11 @@ def _check_input_dtw(x, y):
 
 
 def _get_dimensions(x, y, dist, precomputed_cost):
+    x = check_array(x, ensure_2d=False, dtype='float64')
+    y = check_array(y, ensure_2d=False, dtype='float64')
     if dist == "precomputed":
+        precomputed_cost = check_array(precomputed_cost, ensure_2d=True,
+                                       dtype='float64')
         shape = precomputed_cost.shape
     else:
         shape = x.size, y.size

--- a/pyts/metrics/dtw.py
+++ b/pyts/metrics/dtw.py
@@ -278,7 +278,7 @@ def _return_results(dtw_dist, cost_mat, acc_cost_mat,
         return res
 
 @deprecated("``dtw_classic`` is deprecated in v0.9.0 and will be removed in "
-            "v0.10.0. Use ``dtw`` instead.")
+            "v0.11.0. Use ``dtw`` instead.")
 def dtw_classic(x=None, y=None, dist='square', precomputed_cost=None,
                 return_cost=False, return_accumulated=False,
                 return_path=False):
@@ -287,10 +287,10 @@ def dtw_classic(x=None, y=None, dist='square', precomputed_cost=None,
     Parameters
     ----------
     x : array-like, shape = (n_timestamps_1,)
-        First array. Ignored if `dist` == "precomputed".
+        First array. ``dist == 'precomputed'``.
 
     y : array-like, shape = (n_timestamps_2,)
-        Second array. Ignored if `dist` == "precomputed".
+        Second array. ``dist == 'precomputed'``.
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.
@@ -300,7 +300,8 @@ def dtw_classic(x=None, y=None, dist='square', precomputed_cost=None,
         as input two numbers (two arguments) and returns a number.
 
     precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored unless `dist` == "precomputed".
+        (default = None). Ignored unless ``dist == 'precomputed'``.
+        Precomputed cost matrix between the time series.
 
     return_cost : bool (default = False)
         If True, the cost matrix is returned.
@@ -351,7 +352,7 @@ def dtw_classic(x=None, y=None, dist='square', precomputed_cost=None,
 
 
 @deprecated("``dtw_region`` is deprecated in v0.9.0 and will be removed in "
-            "v0.10.0. Use ``dtw`` instead.")
+            "v0.11.0. Use ``dtw`` instead.")
 def dtw_region(x=None, y=None, dist='square', region=None,
                precomputed_cost=None, return_cost=False,
                return_accumulated=False, return_path=False):
@@ -360,10 +361,10 @@ def dtw_region(x=None, y=None, dist='square', region=None,
     Parameters
     ----------
     x : array-like, shape = (n_timestamps_1,)
-        First array. Ignored if `dist` == "precomputed".
+        First array. ``dist == 'precomputed'``.
 
     y : array-like, shape = (n_timestamps_2,)
-        Second array. Ignored if `dist` == "precomputed".
+        Second array. ``dist == 'precomputed'``.
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.
@@ -379,7 +380,8 @@ def dtw_region(x=None, y=None, dist='square', region=None,
          for each column.
 
     precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored unless `dist` == "precomputed".
+        (default = None). Ignored unless ``dist == 'precomputed'``.
+        Precomputed cost matrix between the time series.
 
     return_cost : bool (default = False)
         If True, the cost matrix is returned.
@@ -530,7 +532,7 @@ def sakoe_chiba_band(n_timestamps_1, n_timestamps_2=None, window_size=0.1):
 
 
 @deprecated("``dtw_region`` is deprecated in v0.9.0 and will be removed in "
-            "v0.10.0. Use ``dtw`` with ``method == 'sakoechiba'`` instead.")
+            "v0.11.0. Use ``dtw`` with ``method == 'sakoechiba'`` instead.")
 def dtw_sakoechiba(x=None, y=None, dist='square', window_size=0.1,
                    precomputed_cost=None, return_cost=False,
                    return_accumulated=False, return_path=False):
@@ -539,10 +541,10 @@ def dtw_sakoechiba(x=None, y=None, dist='square', window_size=0.1,
     Parameters
     ----------
     x : array-like, shape = (n_timestamps_1,)
-        First array. Ignored if `dist` == "precomputed".
+        First array. ``dist == 'precomputed'``.
 
     y : array-like, shape = (n_timestamps_2,)
-        Second array. Ignored if `dist` == "precomputed".
+        Second array. ``dist == 'precomputed'``.
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.
@@ -561,7 +563,8 @@ def dtw_sakoechiba(x=None, y=None, dist='square', window_size=0.1,
         'window_size' becomes a valid cell for the path.
 
     precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored unless `dist` == "precomputed".
+        (default = None). Ignored unless ``dist == 'precomputed'``.
+        Precomputed cost matrix between the time series.
 
     return_cost : bool (default = False)
         If True, the cost matrix is returned.
@@ -707,7 +710,7 @@ def itakura_parallelogram(n_timestamps_1, n_timestamps_2=None, max_slope=2.):
 
 
 @deprecated("``dtw_region`` is deprecated in v0.9.0 and will be removed in "
-            "v0.10.0. Use ``dtw`` with ``method == 'itakura'`` instead.")
+            "v0.11.0. Use ``dtw`` with ``method == 'itakura'`` instead.")
 def dtw_itakura(x=None, y=None, dist='square', max_slope=2.,
                 precomputed_cost=None, return_cost=False,
                 return_accumulated=False, return_path=False):
@@ -716,10 +719,10 @@ def dtw_itakura(x=None, y=None, dist='square', max_slope=2.,
     Parameters
     ----------
     x : array-like, shape = (n_timestamps_1,)
-        First array. Ignored if `dist` == "precomputed".
+        First array. ``dist == 'precomputed'``.
 
     y : array-like, shape = (n_timestamps_2,)
-        Second array. Ignored if `dist` == "precomputed".
+        Second array. ``dist == 'precomputed'``.
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.
@@ -732,7 +735,8 @@ def dtw_itakura(x=None, y=None, dist='square', max_slope=2.,
         Maximum slope for the parallelogram.
 
     precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored unless `dist` == "precomputed".
+        (default = None). Ignored unless ``dist == 'precomputed'``.
+        Precomputed cost matrix between the time series.
 
     return_cost : bool (default = False)
         If True, the cost matrix is returned.
@@ -928,7 +932,7 @@ def _compute_region(n_timestamps_1, n_timestamps_2, method, dist,
 
 
 @deprecated("``dtw_multiscale`` is deprecated in v0.9.0 and will be removed "
-            "in v0.10.0. Use ``dtw`` with ``method == 'multiscale'`` instead.")
+            "in v0.11.0. Use ``dtw`` with ``method == 'multiscale'`` instead.")
 def dtw_multiscale(x, y, dist='square', resolution=2, radius=0,
                    precomputed_cost=None, return_cost=False,
                    return_accumulated=False, return_path=False):
@@ -958,7 +962,8 @@ def dtw_multiscale(x, y, dist='square', resolution=2, radius=0,
         path. It is computed at the resolution level.
 
     precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored unless `dist` == "precomputed".
+        (default = None). Ignored unless ``dist == 'precomputed'``.
+        Precomputed cost matrix between the time series.
 
     return_cost : bool (default = False)
         If True, the cost matrix is returned.
@@ -1012,7 +1017,7 @@ def dtw_multiscale(x, y, dist='square', resolution=2, radius=0,
 
 
 @deprecated("``dtw_fast`` is deprecated in v0.9.0 and will be removed in "
-            "v0.10.0. Use ``dtw`` with ``method == 'fast'`` instead.")
+            "v0.11.0. Use ``dtw`` with ``method == 'fast'`` instead.")
 def dtw_fast(x=None, y=None, dist='square', radius=0, precomputed_cost=None,
              return_cost=False, return_accumulated=False, return_path=False):
     """Fast Dynamic Time Warping distance.
@@ -1020,10 +1025,10 @@ def dtw_fast(x=None, y=None, dist='square', radius=0, precomputed_cost=None,
     Parameters
     ----------
     x : array-like, shape = (n_timestamps_1,)
-        First array. Ignored if `dist` == "precomputed".
+        First array. ``dist == 'precomputed'``.
 
     y : array-like, shape = (n_timestamps_2,)
-        Second array. Ignored if `dist` == "precomputed".
+        Second array. ``dist == 'precomputed'``.
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.
@@ -1039,7 +1044,8 @@ def dtw_fast(x=None, y=None, dist='square', radius=0, precomputed_cost=None,
         path. It is computed at the resolution level.
 
     precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored unless `dist` == "precomputed".
+        (default = None). Ignored unless ``dist == 'precomputed'``.
+        Precomputed cost matrix between the time series.
 
     return_cost : bool (default = False)
         If True, the cost matrix is returned.
@@ -1098,10 +1104,10 @@ def dtw(x=None, y=None, dist='square', method='classic', options=None,
     Parameters
     ----------
     x : array-like, shape = (n_timestamps_1,)
-        First array. Ignored if `dist` == "precomputed".
+        First array. ``dist == 'precomputed'``.
 
     y : array-like, shape = (n_timestamps_2,)
-        Second array. Ignored if `dist` == "precomputed".
+        Second array. ``dist == 'precomputed'``.
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.
@@ -1129,7 +1135,8 @@ def dtw(x=None, y=None, dist='square', method='classic', options=None,
             - 'fast': radius (int)
 
     precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored unless `dist` == "precomputed".
+        (default = None). Ignored unless ``dist == 'precomputed'``.
+        Precomputed cost matrix between the time series.
 
     return_cost : bool (default = False)
         If True, the cost matrix is returned.

--- a/pyts/metrics/dtw.py
+++ b/pyts/metrics/dtw.py
@@ -81,7 +81,8 @@ def _input_to_cost(x, y, dist, precomputed_cost, region):
     if dist == "precomputed":
         if region is not None:
             cost_mat = _project_cost_matrix_region(precomputed_cost, region)
-        cost_mat = precomputed_cost
+        else:
+            cost_mat = precomputed_cost.copy()
     else:
         cost_mat = cost_matrix(x, y, dist=dist, region=region)
     cost_mat = check_array(cost_mat, ensure_min_samples=2,
@@ -277,8 +278,8 @@ def _return_results(dtw_dist, cost_mat, acc_cost_mat,
     else:
         return res
 
-@deprecated("``dtw_classic`` is deprecated in v0.9.0 and will be removed in "
-            "v0.11.0. Use ``dtw`` instead.")
+@deprecated("``dtw_classic`` is deprecated in v0.10 and will be removed in "
+            "v0.11. Use ``dtw`` instead.")
 def dtw_classic(x=None, y=None, dist='square', precomputed_cost=None,
                 return_cost=False, return_accumulated=False,
                 return_path=False):
@@ -287,10 +288,10 @@ def dtw_classic(x=None, y=None, dist='square', precomputed_cost=None,
     Parameters
     ----------
     x : array-like, shape = (n_timestamps_1,)
-        First array. ``dist == 'precomputed'``.
+        First array. Ignored if ``dist == 'precomputed'``.
 
     y : array-like, shape = (n_timestamps_2,)
-        Second array. ``dist == 'precomputed'``.
+        Second array. Ignored if ``dist == 'precomputed'``.
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.
@@ -300,7 +301,7 @@ def dtw_classic(x=None, y=None, dist='square', precomputed_cost=None,
         as input two numbers (two arguments) and returns a number.
 
     precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored unless ``dist == 'precomputed'``.
+        (default = None). Ignored if ``dist != 'precomputed'``.
         Precomputed cost matrix between the time series.
 
     return_cost : bool (default = False)
@@ -351,8 +352,8 @@ def dtw_classic(x=None, y=None, dist='square', precomputed_cost=None,
     return res
 
 
-@deprecated("``dtw_region`` is deprecated in v0.9.0 and will be removed in "
-            "v0.11.0. Use ``dtw`` instead.")
+@deprecated("``dtw_region`` is deprecated in v0.10 and will be removed in "
+            "v0.11. Use ``dtw`` instead.")
 def dtw_region(x=None, y=None, dist='square', region=None,
                precomputed_cost=None, return_cost=False,
                return_accumulated=False, return_path=False):
@@ -361,10 +362,10 @@ def dtw_region(x=None, y=None, dist='square', region=None,
     Parameters
     ----------
     x : array-like, shape = (n_timestamps_1,)
-        First array. ``dist == 'precomputed'``.
+        First array. Ignored if ``dist == 'precomputed'``.
 
     y : array-like, shape = (n_timestamps_2,)
-        Second array. ``dist == 'precomputed'``.
+        Second array. Ignored if ``dist == 'precomputed'``.
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.
@@ -380,7 +381,7 @@ def dtw_region(x=None, y=None, dist='square', region=None,
          for each column.
 
     precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored unless ``dist == 'precomputed'``.
+        (default = None). Ignored if ``dist != 'precomputed'``.
         Precomputed cost matrix between the time series.
 
     return_cost : bool (default = False)
@@ -422,8 +423,6 @@ def dtw_region(x=None, y=None, dist='square', region=None,
     x, y, precomputed_cost, n_timestamps_1, n_timestamps_2 = \
         _check_input_dtw(x, y, precomputed_cost, dist, method="region")
     cost_mat = _input_to_cost(x, y, dist, precomputed_cost, region=region)
-
-    cost_mat = cost_matrix(x, y, dist=dist, region=region)
     acc_cost_mat = accumulated_cost_matrix(cost_mat, region)
     dtw_dist = acc_cost_mat[-1, -1]
     if dist == 'square':
@@ -531,8 +530,8 @@ def sakoe_chiba_band(n_timestamps_1, n_timestamps_2=None, window_size=0.1):
     return region
 
 
-@deprecated("``dtw_region`` is deprecated in v0.9.0 and will be removed in "
-            "v0.11.0. Use ``dtw`` with ``method == 'sakoechiba'`` instead.")
+@deprecated("``dtw_region`` is deprecated in v0.10 and will be removed in "
+            "v0.11. Use ``dtw`` with ``method == 'sakoechiba'`` instead.")
 def dtw_sakoechiba(x=None, y=None, dist='square', window_size=0.1,
                    precomputed_cost=None, return_cost=False,
                    return_accumulated=False, return_path=False):
@@ -541,10 +540,10 @@ def dtw_sakoechiba(x=None, y=None, dist='square', window_size=0.1,
     Parameters
     ----------
     x : array-like, shape = (n_timestamps_1,)
-        First array. ``dist == 'precomputed'``.
+        First array. Ignored if ``dist == 'precomputed'``.
 
     y : array-like, shape = (n_timestamps_2,)
-        Second array. ``dist == 'precomputed'``.
+        Second array. Ignored if ``dist == 'precomputed'``.
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.
@@ -563,7 +562,7 @@ def dtw_sakoechiba(x=None, y=None, dist='square', window_size=0.1,
         'window_size' becomes a valid cell for the path.
 
     precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored unless ``dist == 'precomputed'``.
+        (default = None). Ignored if ``dist != 'precomputed'``.
         Precomputed cost matrix between the time series.
 
     return_cost : bool (default = False)
@@ -709,8 +708,8 @@ def itakura_parallelogram(n_timestamps_1, n_timestamps_2=None, max_slope=2.):
     return region
 
 
-@deprecated("``dtw_region`` is deprecated in v0.9.0 and will be removed in "
-            "v0.11.0. Use ``dtw`` with ``method == 'itakura'`` instead.")
+@deprecated("``dtw_region`` is deprecated in v0.10 and will be removed in "
+            "v0.11. Use ``dtw`` with ``method == 'itakura'`` instead.")
 def dtw_itakura(x=None, y=None, dist='square', max_slope=2.,
                 precomputed_cost=None, return_cost=False,
                 return_accumulated=False, return_path=False):
@@ -719,10 +718,10 @@ def dtw_itakura(x=None, y=None, dist='square', max_slope=2.,
     Parameters
     ----------
     x : array-like, shape = (n_timestamps_1,)
-        First array. ``dist == 'precomputed'``.
+        First array. Ignored if ``dist == 'precomputed'``.
 
     y : array-like, shape = (n_timestamps_2,)
-        Second array. ``dist == 'precomputed'``.
+        Second array. Ignored if ``dist == 'precomputed'``.
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.
@@ -735,7 +734,7 @@ def dtw_itakura(x=None, y=None, dist='square', max_slope=2.,
         Maximum slope for the parallelogram.
 
     precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored unless ``dist == 'precomputed'``.
+        (default = None). Ignored if ``dist != 'precomputed'``.
         Precomputed cost matrix between the time series.
 
     return_cost : bool (default = False)
@@ -931,8 +930,8 @@ def _compute_region(n_timestamps_1, n_timestamps_2, method, dist,
     return region
 
 
-@deprecated("``dtw_multiscale`` is deprecated in v0.9.0 and will be removed "
-            "in v0.11.0. Use ``dtw`` with ``method == 'multiscale'`` instead.")
+@deprecated("``dtw_multiscale`` is deprecated in v0.10 and will be removed "
+            "in v0.11. Use ``dtw`` with ``method == 'multiscale'`` instead.")
 def dtw_multiscale(x, y, dist='square', resolution=2, radius=0,
                    precomputed_cost=None, return_cost=False,
                    return_accumulated=False, return_path=False):
@@ -962,7 +961,7 @@ def dtw_multiscale(x, y, dist='square', resolution=2, radius=0,
         path. It is computed at the resolution level.
 
     precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored unless ``dist == 'precomputed'``.
+        (default = None). Ignored if ``dist != 'precomputed'``.
         Precomputed cost matrix between the time series.
 
     return_cost : bool (default = False)
@@ -1016,8 +1015,8 @@ def dtw_multiscale(x, y, dist='square', resolution=2, radius=0,
     return res
 
 
-@deprecated("``dtw_fast`` is deprecated in v0.9.0 and will be removed in "
-            "v0.11.0. Use ``dtw`` with ``method == 'fast'`` instead.")
+@deprecated("``dtw_fast`` is deprecated in v0.10 and will be removed in "
+            "v0.11. Use ``dtw`` with ``method == 'fast'`` instead.")
 def dtw_fast(x=None, y=None, dist='square', radius=0, precomputed_cost=None,
              return_cost=False, return_accumulated=False, return_path=False):
     """Fast Dynamic Time Warping distance.
@@ -1025,10 +1024,10 @@ def dtw_fast(x=None, y=None, dist='square', radius=0, precomputed_cost=None,
     Parameters
     ----------
     x : array-like, shape = (n_timestamps_1,)
-        First array. ``dist == 'precomputed'``.
+        First array. Ignored if ``dist == 'precomputed'``.
 
     y : array-like, shape = (n_timestamps_2,)
-        Second array. ``dist == 'precomputed'``.
+        Second array. Ignored if ``dist == 'precomputed'``.
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.
@@ -1044,7 +1043,7 @@ def dtw_fast(x=None, y=None, dist='square', radius=0, precomputed_cost=None,
         path. It is computed at the resolution level.
 
     precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored unless ``dist == 'precomputed'``.
+        (default = None). Ignored if ``dist != 'precomputed'``.
         Precomputed cost matrix between the time series.
 
     return_cost : bool (default = False)
@@ -1104,17 +1103,18 @@ def dtw(x=None, y=None, dist='square', method='classic', options=None,
     Parameters
     ----------
     x : array-like, shape = (n_timestamps_1,)
-        First array. ``dist == 'precomputed'``.
+        First array. Ignored if ``dist == 'precomputed'``.
 
     y : array-like, shape = (n_timestamps_2,)
-        Second array. ``dist == 'precomputed'``.
+        Second array. Ignored if ``dist == 'precomputed'``.
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.
-        If 'absolute', the absolute difference is used. If 'precomputed',
-        `precomputed_cost` must be the cost matrix. If callable,
+        If 'absolute', the absolute difference is used. If callable,
         it must be a function with a numba.njit() decorator that takes
         as input two numbers (two arguments) and returns a number.
+        If 'precomputed', `precomputed_cost` must be the cost matrix and
+        `method` must be 'classic', 'sakoechiba' or 'itakura'.
 
     method : str (default = 'classic')
         Method used.  Should be one of
@@ -1135,7 +1135,7 @@ def dtw(x=None, y=None, dist='square', method='classic', options=None,
             - 'fast': radius (int)
 
     precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored unless ``dist == 'precomputed'``.
+        (default = None). Ignored if ``dist != 'precomputed'``.
         Precomputed cost matrix between the time series.
 
     return_cost : bool (default = False)

--- a/pyts/metrics/dtw.py
+++ b/pyts/metrics/dtw.py
@@ -81,11 +81,10 @@ def _input_to_cost(x, y, dist, precomputed_cost, region):
     """Computes cost matrix from dtw input."""
     if dist == "precomputed":
         cost_mat = _check_input_cost(precomputed_cost)
-        n_timestamps_1, n_timestamps_2 = cost_mat.shape
         if region is not None:
             cost_mat = _project_cost_matrix_region(cost_mat, region)
     else:
-        x, y, n_timestamps_1, n_timestamps_2 = _check_input_dtw(x, y)
+        x, y, _, _ = _check_input_dtw(x, y)
         cost_mat = cost_matrix(x, y, dist=dist, region=region)
     return cost_mat
 

--- a/pyts/metrics/tests/test_dtw.py
+++ b/pyts/metrics/tests/test_dtw.py
@@ -18,8 +18,6 @@ from pyts.metrics import (
     show_options
 )
 
-from itertools import product
-
 
 x = np.array([0, 1, 2])
 y = np.array([2, 0, 1])
@@ -668,10 +666,8 @@ def test_check_region(region, n_timestamps_1, n_timestamps_2):
     assert region.shape[1] == n_timestamps_1
 
 
-@pytest.mark.parametrize(
-    "method, n_timestamps_1, n_timestamps_2",
-    product(["classic", "sakoechiba", "itakura"],
-            [4, 10], [4, 10]))
+@pytest.mark.parametrize('method', ['classic', 'sakoechiba', 'itakura'])
+@pytest.mark.parametrize('n_timestamps_1, n_timestamps_2', [[4, 10], [4, 10]])
 def test_precomputed_cost(method, n_timestamps_1, n_timestamps_2):
     rng = np.random.RandomState(42)
     x = rng.randn(n_timestamps_1)
@@ -689,3 +685,16 @@ def test_precomputed_cost_error(method):
     error_match = "cannot be used with a precomputed cost"
     with pytest.raises(ValueError, match=error_match):
         dtw(method=method, dist="precomputed")
+
+
+@pytest.mark.parametrize(
+    "method, dtw_func",
+    [("classic", dtw_classic),
+     ("multiscale", dtw_multiscale),
+     ("itakura", dtw_itakura),
+     ("sakoechiba", dtw_sakoechiba),
+     ("fast", dtw_fast)])
+def test_dtw_methods(method, dtw_func):
+    value_specific = dtw_func(x, y)
+    value_generic = dtw(x, y, method=method)
+    assert value_specific == value_generic

--- a/pyts/metrics/tests/test_dtw.py
+++ b/pyts/metrics/tests/test_dtw.py
@@ -215,8 +215,7 @@ def test_actual_results_dtw_classic(params, res_desired):
 @pytest.mark.parametrize(
     'params, err_msg',
     [({'region': [[1, 1]]},
-      "If 'region' is not None, it must be array-like with shape "
-      "(2, n_timestamps_1).")]
+      "The shape of 'region' must be equal to (2, n_timestamps_1)")]
 )
 def test_parameter_check_dtw_region(params, err_msg):
     """Test parameter validation."""

--- a/pyts/utils/__init__.py
+++ b/pyts/utils/__init__.py
@@ -1,6 +1,7 @@
 """The :mod:`pyts.utils` module includes utility tools."""
 
 from .utils import segmentation, windowed_view
+from .deprecation import deprecated
 
 
-__all__ = ['segmentation', 'windowed_view']
+__all__ = ['segmentation', 'windowed_view', 'deprecated']

--- a/pyts/utils/deprecation.py
+++ b/pyts/utils/deprecation.py
@@ -1,0 +1,119 @@
+import warnings
+import functools
+
+__all__ = ["deprecated"]
+
+
+class deprecated:
+    """Decorator to mark a function or class as deprecated.
+
+    Issue a warning when the function is called/the class is instantiated and
+    adds a warning to the docstring.
+
+    The optional extra argument will be appended to the deprecation message
+    and the docstring. Note: to use this with the default value for extra, put
+    in an empty of parentheses:
+
+    >>> from pyts.utils import deprecated
+
+    >>> @deprecated()
+    ... def some_function(): pass
+
+    Parameters
+    ----------
+    extra : string
+          to be added to the deprecation messages
+    """
+
+    # Adapted from sklearn.utils.deprecation
+
+    def __init__(self, extra=''):
+        self.extra = extra
+
+    def __call__(self, obj):
+        """Call method
+
+        Parameters
+        ----------
+        obj : object
+        """
+        if isinstance(obj, type):
+            return self._decorate_class(obj)
+        elif isinstance(obj, property):
+            # Note that this is only triggered properly if the `property`
+            # decorator comes before the `deprecated` decorator, like so:
+            #
+            # @deprecated(msg)
+            # @property
+            # def deprecated_attribute_(self):
+            #     ...
+            return self._decorate_property(obj)
+        else:
+            return self._decorate_fun(obj)
+
+    def _decorate_class(self, cls):
+        msg = "Class %s is deprecated" % cls.__name__
+        if self.extra:
+            msg += "; %s" % self.extra
+
+        # FIXME: we should probably reset __new__ for full generality
+        init = cls.__init__
+
+        def wrapped(*args, **kwargs):
+            warnings.warn(msg, category=DeprecationWarning)
+            return init(*args, **kwargs)
+        cls.__init__ = wrapped
+
+        wrapped.__name__ = '__init__'
+        wrapped.__doc__ = self._update_doc(init.__doc__)
+        wrapped.deprecated_original = init
+
+        return cls
+
+    def _decorate_fun(self, fun):
+        """Decorate function fun"""
+
+        msg = "Function %s is deprecated" % fun.__name__
+        if self.extra:
+            msg += "; %s" % self.extra
+
+        @functools.wraps(fun)
+        def wrapped(*args, **kwargs):
+            warnings.warn(msg, category=DeprecationWarning)
+            return fun(*args, **kwargs)
+
+        wrapped.__doc__ = self._update_doc(wrapped.__doc__)
+        # Add a reference to the wrapped function so that we can introspect
+        # on function arguments in Python 2 (already works in Python 3)
+        wrapped.__wrapped__ = fun
+
+        return wrapped
+
+    def _decorate_property(self, prop):
+        msg = self.extra
+
+        @property
+        def wrapped(*args, **kwargs):
+            warnings.warn(msg, category=DeprecationWarning)
+            return prop.fget(*args, **kwargs)
+
+        return wrapped
+
+    def _update_doc(self, olddoc):
+        newdoc = "DEPRECATED"
+        if self.extra:
+            newdoc = "%s: %s" % (newdoc, self.extra)
+        if olddoc:
+            newdoc = "%s\n\n%s" % (newdoc, olddoc)
+        return newdoc
+
+
+def _is_deprecated(func):
+    """Helper to check if func is wraped by our deprecated decorator"""
+    closures = getattr(func, '__closure__', [])
+    if closures is None:
+        closures = []
+    is_deprecated = ('deprecated' in ''.join([c.cell_contents
+                                              for c in closures
+                     if isinstance(c.cell_contents, str)]))
+    return is_deprecated

--- a/pyts/utils/deprecation.py
+++ b/pyts/utils/deprecation.py
@@ -1,6 +1,11 @@
 import warnings
 import functools
 
+
+# Author: <hicham.janati@inria.fr>
+# Adapted from sklearn.utils.deprecation
+
+
 __all__ = ["deprecated"]
 
 
@@ -24,8 +29,6 @@ class deprecated:
     extra : string
           to be added to the deprecation messages
     """
-
-    # Adapted from sklearn.utils.deprecation
 
     def __init__(self, extra=''):
         self.extra = extra

--- a/pyts/utils/tests/test_deprecation.py
+++ b/pyts/utils/tests/test_deprecation.py
@@ -1,0 +1,58 @@
+import pytest
+
+from pyts.utils.deprecation import _is_deprecated
+from pyts.utils.deprecation import deprecated
+
+# Author: <hicham.janati@inria.fr>
+# Adapted from sklearn.utils.tests.test_deprecation
+
+
+@deprecated('qwerty')
+class MockClass1:
+    pass
+
+
+class MockClass2:
+    @deprecated('mockclass2_method')
+    def method(self):
+        pass
+
+
+class MockClass3:
+    @deprecated()
+    def __init__(self):
+        pass
+
+
+class MockClass4:
+    pass
+
+
+@deprecated()
+def mock_function():
+    return 10
+
+
+def test_deprecated():
+    with pytest.warns(DeprecationWarning, match="qwerty"):
+        MockClass1()
+
+    with pytest.warns(DeprecationWarning, match="mockclass2_method"):
+        MockClass2().method()
+
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        MockClass3()
+
+    with pytest.warns(DeprecationWarning):
+        val = mock_function()
+        assert val == 10
+
+
+def test_is_deprecated():
+    # Test if _is_deprecated helper identifies wrapping via deprecated
+    # NOTE it works only for class methods and functions
+    assert _is_deprecated(MockClass1.__init__)
+    assert _is_deprecated(MockClass2().method)
+    assert _is_deprecated(MockClass3.__init__)
+    assert not _is_deprecated(MockClass4.__init__)
+    assert _is_deprecated(mock_function)


### PR DESCRIPTION
This PR adds a "precomputed" option for the `dist` arg when computing`dtw`. The user can choose whether to provide `x` and `y` or a precomputed cost matrix through a new `precomputed_cost` arg. 

- [x] Add the new args + adapt computation of `region` + `cost_mat`.
- [x] Add tests with precomputed cost matrices (test against square for e.g)
- [x] A large portion of the code in the different dtw functions is redundant: shorten it