### PR TITLE
Sort lists of datasets from dictionary keys

### DIFF
--- a/pyts/datasets/ucr.py
+++ b/pyts/datasets/ucr.py
@@ -69,7 +69,7 @@ def ucr_dataset_list():
     module_path = os.path.dirname(__file__)
     finfo = os.path.join(module_path, 'info', 'ucr.pickle')
     dictionary = pickle.load(open(finfo, 'rb'))
-    datasets = list(dictionary.keys())
+    datasets = sorted(dictionary.keys())
     return datasets
 
 

--- a/pyts/datasets/uea.py
+++ b/pyts/datasets/uea.py
@@ -46,7 +46,7 @@ def uea_dataset_list():
     module_path = os.path.dirname(__file__)
     finfo = os.path.join(module_path, 'info', 'uea.pickle')
     dictionary = pickle.load(open(finfo, 'rb'))
-    datasets = list(dictionary.keys())
+    datasets = sorted(dictionary.keys())
     return datasets
 
 


### PR DESCRIPTION
Currently the lists of UCR and UEA datasets are loaded from the keys of dictionaries. However dictionaries are not ordered for older Python versions. This small PR fixes this issue by sorting the lists.