### PR TITLE
Fix broken README link in index.rst

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -67,7 +67,7 @@ complements the `User Guide <user_guide.html>`_.
 
 History of notable changes to the pyts.
 
-See the `README <https://github.com/johannfaouzi/pyts/README.md>`_
+See the `README <https://github.com/johannfaouzi/pyts/blob/master/README.md>`_
 for more information.
 
 


### PR DESCRIPTION
This PR fixes the broken link for the README in the index of the documentation.