### PR TITLE
Remove attributes from check_is_fitted

### DIFF
--- a/pyts/approximation/dft.py
+++ b/pyts/approximation/dft.py
@@ -11,6 +11,9 @@ from math import ceil
 from warnings import warn
 from ..preprocessing import StandardScaler
 
+import sklearn
+SKLEARN_VERSION = sklearn.__version__
+
 
 class DiscreteFourierTransform(BaseEstimator, TransformerMixin):
     """Discrete Fourier Transform.
@@ -128,7 +131,10 @@ class DiscreteFourierTransform(BaseEstimator, TransformerMixin):
             The selected Fourier coefficients for each sample.
 
         """
-        check_is_fitted(self, 'support_')
+        if SKLEARN_VERSION >= '0.22':
+            check_is_fitted(self)
+        else:
+            check_is_fitted(self, 'support_')
         X = check_array(X, dtype='float64')
         n_samples, n_timestamps = X.shape
 

--- a/pyts/approximation/mcb.py
+++ b/pyts/approximation/mcb.py
@@ -11,6 +11,9 @@ from sklearn.tree import DecisionTreeClassifier
 from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
 from sklearn.utils.multiclass import check_classification_targets
 
+import sklearn
+SKLEARN_VERSION = sklearn.__version__
+
 
 @njit()
 def _uniform_bins(timestamp_min, timestamp_max, n_timestamps, n_bins):
@@ -145,7 +148,10 @@ class MultipleCoefficientBinning(BaseEstimator, TransformerMixin):
             Binned data.
 
         """
-        check_is_fitted(self, 'bin_edges_')
+        if SKLEARN_VERSION >= '0.22':
+            check_is_fitted(self)
+        else:
+            check_is_fitted(self, 'bin_edges_')
         X = check_array(X, dtype='float64')
         self._check_consistent_lengths(X)
         indices = _digitize(X, self.bin_edges_)

--- a/pyts/approximation/sfa.py
+++ b/pyts/approximation/sfa.py
@@ -9,6 +9,9 @@ from sklearn.utils.validation import check_is_fitted
 from .dft import DiscreteFourierTransform
 from .mcb import MultipleCoefficientBinning
 
+import sklearn
+SKLEARN_VERSION = sklearn.__version__
+
 
 class SymbolicFourierApproximation(BaseEstimator, TransformerMixin):
     """Symbolic Fourier Approximation.
@@ -140,7 +143,10 @@ class SymbolicFourierApproximation(BaseEstimator, TransformerMixin):
             Transformed data.
 
         """
-        check_is_fitted(self, ['support_', 'bin_edges_'])
+        if SKLEARN_VERSION >= '0.22':
+            check_is_fitted(self)
+        else:
+            check_is_fitted(self, ['support_', 'bin_edges_'])
         return self._pipeline.transform(X)
 
     def fit_transform(self, X, y=None):

--- a/pyts/classification/bossvs.py
+++ b/pyts/classification/bossvs.py
@@ -14,6 +14,9 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from ..approximation import SymbolicFourierApproximation
 from ..utils import windowed_view
 
+import sklearn
+SKLEARN_VERSION = sklearn.__version__
+
 
 class BOSSVS(BaseEstimator, ClassifierMixin):
     """Bag-of-SFA Symbols in Vector Space.
@@ -223,7 +226,10 @@ class BOSSVS(BaseEstimator, ClassifierMixin):
             Cosine similarity between the document-term matrix and X.
 
         """
-        check_is_fitted(self, ['vocabulary_', 'tfidf_', 'idf_', '_tfidf'])
+        if SKLEARN_VERSION >= '0.22':
+            check_is_fitted(self)
+        else:
+            check_is_fitted(self, ['vocabulary_', 'tfidf_', 'idf_', '_tfidf'])
         X = check_array(X, dtype='float64')
         n_samples, n_timestamps = X.shape
 

--- a/pyts/classification/knn.py
+++ b/pyts/classification/knn.py
@@ -10,6 +10,9 @@ from sklearn.utils.validation import check_X_y, check_is_fitted
 from ..metrics import (boss, dtw, dtw_classic, dtw_region, dtw_fast,
                        dtw_multiscale, sakoe_chiba_band, itakura_parallelogram)
 
+import sklearn
+SKLEARN_VERSION = sklearn.__version__
+
 
 class KNeighborsClassifier(BaseEstimator, ClassifierMixin):
     """k nearest neighbors classifier.
@@ -218,7 +221,10 @@ class KNeighborsClassifier(BaseEstimator, ClassifierMixin):
             Probability estimates.
 
         """
-        check_is_fitted(self, '_clf')
+        if SKLEARN_VERSION >= '0.22':
+            check_is_fitted(self)
+        else:
+            check_is_fitted(self, '_clf')
         return self._clf.predict_proba(X)
 
     def predict(self, X):
@@ -235,5 +241,8 @@ class KNeighborsClassifier(BaseEstimator, ClassifierMixin):
             Class labels for each data sample.
 
         """
-        check_is_fitted(self, '_clf')
+        if SKLEARN_VERSION >= '0.22':
+            check_is_fitted(self)
+        else:
+            check_is_fitted(self, '_clf')
         return self._clf.predict(X)

--- a/pyts/classification/saxvsm.py
+++ b/pyts/classification/saxvsm.py
@@ -13,6 +13,9 @@ from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
 from ..bag_of_words import BagOfWords
 from ..approximation import SymbolicAggregateApproximation
 
+import sklearn
+SKLEARN_VERSION = sklearn.__version__
+
 
 class SAXVSM(BaseEstimator, ClassifierMixin):
     """Classifier based on SAX-VSM representation and tf-idf statistics.
@@ -177,8 +180,11 @@ class SAXVSM(BaseEstimator, ClassifierMixin):
             osine similarity between the document-term matrix and X.
 
         """
-        check_is_fitted(self, ['vocabulary_', 'tfidf_', 'idf_',
-                               '_tfidf', 'classes_'])
+        if SKLEARN_VERSION >= '0.22':
+            check_is_fitted(self)
+        else:
+            check_is_fitted(self, ['vocabulary_', 'tfidf_', 'idf_',
+                                   '_tfidf', 'classes_'])
         X_sax = self._sax.transform(X)
         X_bow = self._bow.transform(X_sax)
         vectorizer = CountVectorizer(vocabulary=self._tfidf.vocabulary_)

--- a/pyts/multivariate/classification/multivariate.py
+++ b/pyts/multivariate/classification/multivariate.py
@@ -8,8 +8,10 @@ from numba import njit, prange
 from sklearn.base import BaseEstimator, ClassifierMixin, clone
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils.validation import check_is_fitted
-
 from ..utils import check_3d_array
+
+import sklearn
+SKLEARN_VERSION = sklearn.__version__
 
 
 @njit()
@@ -112,7 +114,10 @@ class MultivariateClassifier(BaseEstimator, ClassifierMixin):
 
         """
         X = check_3d_array(X)
-        check_is_fitted(self, 'estimators_')
+        if SKLEARN_VERSION >= '0.22':
+            check_is_fitted(self)
+        else:
+            check_is_fitted(self, 'estimators_')
         n_samples, n_features, _ = X.shape
 
         y_pred = np.empty((n_samples, n_features))

--- a/pyts/multivariate/transformation/multivariate.py
+++ b/pyts/multivariate/transformation/multivariate.py
@@ -9,6 +9,9 @@ from sklearn.base import BaseEstimator, TransformerMixin, clone
 from sklearn.utils.validation import check_is_fitted
 from ..utils import check_3d_array
 
+import sklearn
+SKLEARN_VERSION = sklearn.__version__
+
 
 class MultivariateTransformer(BaseEstimator, TransformerMixin):
     r"""Transformer for multivariate time series.
@@ -92,7 +95,10 @@ class MultivariateTransformer(BaseEstimator, TransformerMixin):
         """
         X = check_3d_array(X)
         n_samples, _, _ = X.shape
-        check_is_fitted(self, 'estimators_')
+        if SKLEARN_VERSION >= '0.22':
+            check_is_fitted(self)
+        else:
+            check_is_fitted(self, 'estimators_')
 
         X_transformed = [transformer.transform(X[:, i, :])
                          for i, transformer in enumerate(self.estimators_)]

--- a/pyts/multivariate/transformation/weasel_muse.py
+++ b/pyts/multivariate/transformation/weasel_muse.py
@@ -9,9 +9,11 @@ from scipy.sparse import csr_matrix, hstack
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.base import clone
 from sklearn.utils.validation import check_is_fitted
-
 from ...transformation import WEASEL
 from ..utils import check_3d_array
+
+import sklearn
+SKLEARN_VERSION = sklearn.__version__
 
 
 class WEASELMUSE(BaseEstimator, TransformerMixin):
@@ -177,7 +179,10 @@ class WEASELMUSE(BaseEstimator, TransformerMixin):
             Document-term matrix with relevant learned features only.
 
         """
-        check_is_fitted(self, 'vocabulary_')
+        if SKLEARN_VERSION >= '0.22':
+            check_is_fitted(self)
+        else:
+            check_is_fitted(self, 'vocabulary_')
         X = check_3d_array(X)
         n_samples, _, _ = X.shape
         X_diff = np.abs(np.diff(X))

--- a/pyts/preprocessing/tests/test_discretizer.py
+++ b/pyts/preprocessing/tests/test_discretizer.py
@@ -39,7 +39,8 @@ def test_uniform_bins(sample_min, sample_max, n_bins, arr_desired):
 )
 def test_digitize(X, bins, arr_desired):
     """Test '_digitize' function."""
-    arr_actual = _digitize(X, bins)
+    X_float = np.asarray(X, dtype='float64')
+    arr_actual = _digitize(X_float, bins)
     np.testing.assert_array_equal(arr_actual, arr_desired)
 
 

--- a/pyts/transformation/boss.py
+++ b/pyts/transformation/boss.py
@@ -13,6 +13,9 @@ from sklearn.utils.multiclass import check_classification_targets
 from ..approximation import SymbolicFourierApproximation
 from ..utils import windowed_view
 
+import sklearn
+SKLEARN_VERSION = sklearn.__version__
+
 
 class BOSS(BaseEstimator, TransformerMixin):
     """Bag of Symbolic Fourier Approximation Symbols.
@@ -194,7 +197,10 @@ class BOSS(BaseEstimator, TransformerMixin):
             Document-term matrix.
 
         """
-        check_is_fitted(self, ['_sfa', '_vectorizer', 'vocabulary_'])
+        if SKLEARN_VERSION >= '0.22':
+            check_is_fitted(self)
+        else:
+            check_is_fitted(self, ['_sfa', '_vectorizer', 'vocabulary_'])
         X = check_array(X)
         n_samples, n_timestamps = X.shape
 

--- a/pyts/transformation/weasel.py
+++ b/pyts/transformation/weasel.py
@@ -13,6 +13,9 @@ from sklearn.feature_selection import chi2
 from ..approximation import SymbolicFourierApproximation
 from ..utils import windowed_view
 
+import sklearn
+SKLEARN_VERSION = sklearn.__version__
+
 
 class WEASEL(BaseEstimator, TransformerMixin):
     """Word ExtrAction for time SEries cLassification.
@@ -198,8 +201,11 @@ class WEASEL(BaseEstimator, TransformerMixin):
             Document-term matrix with relevant features only.
 
         """
-        check_is_fitted(self, ['_relevant_features_list', '_sfa_list',
-                               '_vectorizer_list', 'vocabulary_'])
+        if SKLEARN_VERSION >= '0.22':
+            check_is_fitted(self)
+        else:
+            check_is_fitted(self, ['_relevant_features_list', '_sfa_list',
+                                   '_vectorizer_list', 'vocabulary_'])
 
         X = check_array(X)
         n_samples, n_timestamps = X.shape


### PR DESCRIPTION
This PR removes the use of the `attributes` parameter from `check_is_fitted`. This parameter is deprecated in `scikit-learn (0.22)` and will be removed in 0.23.