### PR TITLE
Fix miscellaneous typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ To run the examples Matplotlib (>=2.0.0) is required.
 
 #### User installation
 
-If you already have a working installation of numpy, scipy, scikit-learn and
-numba, you can easily install pyts using ``pip``
+If you already have a working installation of numpy, scipy, scikit-learn,
+joblib and numba, you can easily install pyts using ``pip``
 
     pip install pyts
 
@@ -140,7 +140,8 @@ of missing values using interpolation. More information is available at the
 - `transformation`: This module provides implementations of algorithms that
 transform a data set of time series with shape `(n_samples, n_timestamps)` into
 a data set with shape `(n_samples, n_features)`. Implemented algorithms are
-[BOSS](https://pyts.readthedocs.io/en/latest/generated/pyts.transformation.BOSS.html#) and
+[BOSS](https://pyts.readthedocs.io/en/latest/generated/pyts.transformation.BOSS.html#),
+[ShapeletTransform](https://pyts.readthedocs.io/en/latest/generated/pyts.transformation.ShapeletTransform.html) and
 [WEASEL](https://pyts.readthedocs.io/en/latest/generated/pyts.transformation.WEASEL.html#).
 
 - `utils`: a simple module with

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,12 +9,12 @@ Version 0.10.0
 --------------
 
 - Adapt DTW functions to compare time series with different lengths
-  (by :user:`Hicham Janati <hichamjanati>`)
+  (by Hicham Janati)
 
 - Add a ``precomputed_cost`` parameter in DTW variants that are compatible
   with a precomputed cost matrix, that is classical DTW and DTW with global
   constraint regions like Sakoe-Chiba band and Itakura parallelogram
-  (by :user:`Hicham Janati <hichamjanati>`)
+  (by Hicham Janati)
 
 - Add a new algorithm called *ShapeletTransform* in the :mod:`pyts.transformation`
   module.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,8 +8,29 @@ Change Log
 Version 0.10.0
 --------------
 
-- Adapt `pyts.metrics.dtw` to compare time series with different lengths (Hicham Janati)
+- Adapt DTW functions to compare time series with different lengths
+  (by :user:`Hicham Janati <hichamjanati>`)
 
+- Add a ``precomputed_cost`` parameter in DTW variants that are compatible
+  with a precomputed cost matrix, that is classical DTW and DTW with global
+  constraint regions like Sakoe-Chiba band and Itakura parallelogram
+  (by :user:`Hicham Janati <hichamjanati>`)
+
+- Add a new algorithm called *ShapeletTransform* in the :mod:`pyts.transformation`
+  module.
+
+- Add a new dependency, the *joblib* Python package, since it has been vendored
+  from scikit-learn and it is used in ShapeletTransform.
+
+- [DOC] Revamp documentation in most sections:
+
+  * User guide is much more detailed
+  * A *Scikit-learn compatibility* page has been added to highlight the compatibility
+    of pyts estimators with scikit-learn tools like model selection and pipelines.
+  * A *Reproducibility* page has been added to highlight the work done in the
+    `pyts-repro <https://github.com/johannfaouzi/pyts-repro>`_ repository,
+    where we compare the performance of our implementations to the literature.
+  * A *Contributing guide* has been added.
 
 
 Version 0.9.0

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -151,7 +151,8 @@ html_theme_options = {
     'github_user': 'johannfaouzi',
 
     # Page and sidebar widths
-    'page_width': '1250px',
+    'page_width': '1300px',
+    'body_max_width': '850px',
     'sidebar_width': '250px',
 
     # Related links

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -22,8 +22,8 @@ To run the examples Matplotlib (>=2.0.0) is required.
 User installation
 -----------------
 
-If you already have a working installation of numpy, scipy, scikit-learn and
-numba, you can easily install pyts using ``pip``::
+If you already have a working installation of numpy, scipy, scikit-learn,
+joblib and numba, you can easily install pyts using ``pip``::
 
     pip install pyts
 

--- a/examples/datasets/plot_load_gunpoint.py
+++ b/examples/datasets/plot_load_gunpoint.py
@@ -37,8 +37,8 @@ for i, (X, y, set_, class_,) in enumerate(zip(
     [1, 2, 1, 2]
 )):
     plt.subplot(2, 2, i + 1)
-    for i in range(n_samples_per_plot):
-        plt.plot(X[y == class_][i], 'C0')
+    for j in range(n_samples_per_plot):
+        plt.plot(X[y == class_][j], 'C0')
     plt.title('{} set - class {}'.format(set_, class_), fontsize=16)
 
 plt.suptitle('GunPoint dataset', fontsize=20)

--- a/pyts/metrics/dtw.py
+++ b/pyts/metrics/dtw.py
@@ -8,8 +8,6 @@ from math import ceil, log2, sqrt
 from numba import njit, prange
 from sklearn.utils import check_array
 
-from ..utils import deprecated
-
 
 @njit()
 def _square(x, y):
@@ -276,8 +274,7 @@ def _return_results(dtw_dist, cost_mat, acc_cost_mat,
     else:
         return res
 
-@deprecated("``dtw_classic`` is deprecated in v0.10 and will be removed in "
-            "v0.11. Use ``dtw`` instead.")
+
 def dtw_classic(x=None, y=None, dist='square', precomputed_cost=None,
                 return_cost=False, return_accumulated=False,
                 return_path=False):
@@ -298,9 +295,10 @@ def dtw_classic(x=None, y=None, dist='square', precomputed_cost=None,
         it must be a function with a numba.njit() decorator that takes
         as input two numbers (two arguments) and returns a number.
 
-    precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored if ``dist != 'precomputed'``.
+    precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2) \
+            (default = None).
         Precomputed cost matrix between the time series.
+        Ignored if ``dist != 'precomputed'``.
 
     return_cost : bool (default = False)
         If True, the cost matrix is returned.
@@ -328,6 +326,12 @@ def dtw_classic(x=None, y=None, dist='square', precomputed_cost=None,
         consists of the indices of the optimal path for y. Only returned
         if ``return_path=True``.
 
+    References
+    ----------
+    .. [1] H. Sakoe and S. Chiba, “Dynamic programming algorithm optimization
+           for spoken word recognition”. IEEE Transactions on Acoustics,
+           Speech, and Signal Processing, 26(1), 43-49 (1978).
+
     Examples
     --------
     >>> from pyts.metrics import dtw_classic
@@ -350,8 +354,6 @@ def dtw_classic(x=None, y=None, dist='square', precomputed_cost=None,
     return res
 
 
-@deprecated("``dtw_region`` is deprecated in v0.10 and will be removed in "
-            "v0.11. Use ``dtw`` instead.")
 def dtw_region(x=None, y=None, dist='square', region=None,
                precomputed_cost=None, return_cost=False,
                return_accumulated=False, return_path=False):
@@ -378,9 +380,10 @@ def dtw_region(x=None, y=None, dist='square', region=None,
          second row consists of the ending indices (excluded) of the valid rows
          for each column.
 
-    precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored if ``dist != 'precomputed'``.
+    precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2) \
+            (default = None).
         Precomputed cost matrix between the time series.
+        Ignored if ``dist != 'precomputed'``.
 
     return_cost : bool (default = False)
         If True, the cost matrix is returned.
@@ -502,6 +505,12 @@ def sakoe_chiba_band(n_timestamps_1, n_timestamps_2=None, window_size=0.1):
         (included) and the second row consists of the ending indices (excluded)
         of the valid rows for each column.
 
+    References
+    ----------
+    .. [1] H. Sakoe and S. Chiba, “Dynamic programming algorithm optimization
+           for spoken word recognition”. IEEE Transactions on Acoustics,
+           Speech, and Signal Processing, 26(1), 43-49 (1978).
+
     Examples
     --------
     >>> from pyts.metrics import sakoe_chiba_band
@@ -528,8 +537,6 @@ def sakoe_chiba_band(n_timestamps_1, n_timestamps_2=None, window_size=0.1):
     return region
 
 
-@deprecated("``dtw_region`` is deprecated in v0.10 and will be removed in "
-            "v0.11. Use ``dtw`` with ``method == 'sakoechiba'`` instead.")
 def dtw_sakoechiba(x=None, y=None, dist='square', window_size=0.1,
                    precomputed_cost=None, return_cost=False,
                    return_accumulated=False, return_path=False):
@@ -559,9 +566,10 @@ def dtw_sakoechiba(x=None, y=None, dist='square', window_size=0.1,
         Each cell whose distance with the diagonale is lower than or equal to
         'window_size' becomes a valid cell for the path.
 
-    precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored if ``dist != 'precomputed'``.
+    precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2) \
+            (default = None).
         Precomputed cost matrix between the time series.
+        Ignored if ``dist != 'precomputed'``.
 
     return_cost : bool (default = False)
         If True, the cost matrix is returned.
@@ -588,6 +596,12 @@ def dtw_sakoechiba(x=None, y=None, dist='square', window_size=0.1,
         of the indices of the optimal path for x while the second row
         consists of the indices of the optimal path for y. Only returned
         if ``return_path=True``.
+
+    References
+    ----------
+    .. [1] H. Sakoe and S. Chiba, “Dynamic programming algorithm optimization
+           for spoken word recognition”. IEEE Transactions on Acoustics,
+           Speech, and Signal Processing, 26(1), 43-49 (1978).
 
     Examples
     --------
@@ -662,6 +676,12 @@ def itakura_parallelogram(n_timestamps_1, n_timestamps_2=None, max_slope=2.):
         (included) and the second row consists of the ending indices (excluded)
         of the valid rows for each column.
 
+    References
+    ----------
+    .. [1] F. Itakura, “Minimum prediction residual principle applied to speech
+           recognition”. IEEE Transactions on Acoustics, Speech, and Signal
+           Processing, 23(1), 67–72 (1975).
+
     Examples
     --------
     >>> from pyts.metrics import itakura_parallelogram
@@ -711,8 +731,6 @@ def itakura_parallelogram(n_timestamps_1, n_timestamps_2=None, max_slope=2.):
     return region
 
 
-@deprecated("``dtw_region`` is deprecated in v0.10 and will be removed in "
-            "v0.11. Use ``dtw`` with ``method == 'itakura'`` instead.")
 def dtw_itakura(x=None, y=None, dist='square', max_slope=2.,
                 precomputed_cost=None, return_cost=False,
                 return_accumulated=False, return_path=False):
@@ -736,9 +754,10 @@ def dtw_itakura(x=None, y=None, dist='square', max_slope=2.,
     max_slope : float (default = 2.)
         Maximum slope for the parallelogram.
 
-    precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored if ``dist != 'precomputed'``.
+    precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2) \
+            (default = None).
         Precomputed cost matrix between the time series.
+        Ignored if ``dist != 'precomputed'``.
 
     return_cost : bool (default = False)
         If True, the cost matrix is returned.
@@ -765,6 +784,12 @@ def dtw_itakura(x=None, y=None, dist='square', max_slope=2.,
         of the indices of the optimal path for x while the second row
         consists of the indices of the optimal path for y. Only returned
         if ``return_path=True``.
+
+    References
+    ----------
+    .. [1] F. Itakura, “Minimum prediction residual principle applied to speech
+           recognition”. IEEE Transactions on Acoustics, Speech, and Signal
+           Processing, 23(1), 67–72 (1975).
 
     Examples
     --------
@@ -933,8 +958,6 @@ def _compute_region(n_timestamps_1, n_timestamps_2, method, dist,
     return region
 
 
-@deprecated("``dtw_multiscale`` is deprecated in v0.10 and will be removed "
-            "in v0.11. Use ``dtw`` with ``method == 'multiscale'`` instead.")
 def dtw_multiscale(x, y, dist='square', resolution=2, radius=0,
                    return_cost=False, return_accumulated=False,
                    return_path=False):
@@ -989,6 +1012,12 @@ def dtw_multiscale(x, y, dist='square', resolution=2, radius=0,
         consists of the indices of the optimal path for y. Only returned
         if ``return_path=True``.
 
+    References
+    ----------
+    .. [1] M. Müller, H. Mattes and F. Kurth, “An efficient multiscale approach
+           to audio synchronization”. International Conference on Music
+           Information Retrieval, 6(1), 192-197 (2006).
+
     Examples
     --------
     >>> from pyts.metrics import dtw_multiscale
@@ -1015,19 +1044,17 @@ def dtw_multiscale(x, y, dist='square', resolution=2, radius=0,
     return res
 
 
-@deprecated("``dtw_fast`` is deprecated in v0.10 and will be removed in "
-            "v0.11. Use ``dtw`` with ``method == 'fast'`` instead.")
-def dtw_fast(x=None, y=None, dist='square', radius=0, return_cost=False,
+def dtw_fast(x, y, dist='square', radius=0, return_cost=False,
              return_accumulated=False, return_path=False):
     """Fast Dynamic Time Warping distance.
 
     Parameters
     ----------
     x : array-like, shape = (n_timestamps_1,)
-        First array. Ignored if ``dist == 'precomputed'``.
+        First array.
 
     y : array-like, shape = (n_timestamps_2,)
-        Second array. Ignored if ``dist == 'precomputed'``.
+        Second array.
 
     dist : 'square', 'absolute', 'precomputed' or callable (default = 'square')
         Distance used. If 'square', the squared difference is used.
@@ -1067,6 +1094,12 @@ def dtw_fast(x=None, y=None, dist='square', radius=0, return_cost=False,
         of the indices of the optimal path for x while the second row
         consists of the indices of the optimal path for y. Only returned
         if ``return_path=True``.
+
+    References
+    ----------
+    .. [1] S. Salvador ans P. Chan, “FastDTW: Toward Accurate Dynamic Time
+           Warping in Linear Time and Space”. KDD Workshop on Mining Temporal
+           and Sequential Data, 70–80 (2004).
 
     Examples
     --------
@@ -1109,8 +1142,8 @@ def dtw(x=None, y=None, dist='square', method='classic', options=None,
         If 'absolute', the absolute difference is used. If callable,
         it must be a function with a numba.njit() decorator that takes
         as input two numbers (two arguments) and returns a number.
-        If 'precomputed', `precomputed_cost` must be the cost matrix and
-        `method` must be 'classic', 'sakoechiba' or 'itakura'.
+        If 'precomputed', ``precomputed_cost`` must be the cost matrix and
+        ``method`` must be 'classic', 'sakoechiba' or 'itakura'.
 
     method : str (default = 'classic')
         Method used.  Should be one of
@@ -1130,9 +1163,13 @@ def dtw(x=None, y=None, dist='square', method='classic', options=None,
             - 'multiscale': resolution (int) and radius (int)
             - 'fast': radius (int)
 
-    precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2)
-        (default = None). Ignored if ``dist != 'precomputed'``.
+        For more information on these parameters, see the `Other Parameters`
+        section.
+
+    precomputed_cost : array-like, shape = (n_timestamps_1, n_timestamps_2) \
+            (default = None).
         Precomputed cost matrix between the time series.
+        Ignored if ``dist != 'precomputed'``.
 
     return_cost : bool (default = False)
         If True, the cost matrix is returned.
@@ -1159,6 +1196,47 @@ def dtw(x=None, y=None, dist='square', method='classic', options=None,
         of the indices of the optimal path for x while the second row
         consists of the indices of the optimal path for y. Only returned
         if ``return_path=True``.
+
+    Other Parameters
+    ----------------
+    window_size : float or int (default = 0.1)
+        The window size above and below the diagonale.
+        If float, `window_size must be between 0 and
+        1, and the actual window size will be computed as
+        ``ceil(window_size * max((n_timestamps_1, n_timestamps_2) - 1))``.
+        If int, `window_size` must be the largest temporal shift allowed.
+        Each cell whose distance with the diagonale is lower than or equal to
+        'window_size' becomes a valid cell for the path.
+
+    max_slope : float (default = 2.)
+        Maximum slope for the parallelogram.
+
+    resolution : int (default = 2)
+        The resolution level.
+
+    radius : int (default = 0)
+        The radius used to expand the constraint region. The optimal path
+        computed at the resolution level is expanded with `radius` cells to the
+        top, bottom, left and right of every cell belonging to the optimal
+        path. It is computed at the resolution level.
+
+    References
+    ----------
+    .. [1] H. Sakoe and S. Chiba, "Dynamic programming algorithm optimization
+           for spoken word recognition". IEEE Transactions on Acoustics,
+           Speech, and Signal Processing, 26(1), 43-49 (1978).
+
+    .. [2] F. Itakura, "Minimum prediction residual principle applied to
+           speech recognition". IEEE Transactions on Acoustics,
+           Speech, and Signal Processing, 23(1), 67–72 (1975).
+
+    .. [3] M. Müller, H. Mattes and F. Kurth, "An efficient multiscale approach
+           to audio synchronization". International Conference on Music
+           Information Retrieval, 6(1), 192-197 (2006).
+
+    .. [4] S. Salvador ans P. Chan, "FastDTW: Toward Accurate Dynamic Time
+           Warping in Linear Time and Space". KDD Workshop on Mining Temporal
+           and Sequential Data, 70–80 (2004).
 
     Examples
     --------

--- a/pyts/multivariate/transformation/multivariate.py
+++ b/pyts/multivariate/transformation/multivariate.py
@@ -116,7 +116,7 @@ class MultivariateTransformer(BaseEstimator, TransformerMixin):
                 one_shape = np.unique(shapes, axis=0).shape[0] == 1
             else:
                 one_shape = False
-            if (not one_dim) or (not one_shape) or self.flatten:
+            if (not one_shape) or self.flatten:
                 X_new = [X_new_i.reshape(n_samples, -1) for X_new_i in X_new]
                 X_new = np.concatenate(X_new, axis=1)
             else:


### PR DESCRIPTION
This PR fixes several things:
* a couple of alerts from LGTM
* deprecations of `dtw_` functions are reverted
* fix some typos in docstrings
* changelog is updated