### PR TITLE
Remove if else loop for check_is_fitted

### DIFF
--- a/pyts/approximation/dft.py
+++ b/pyts/approximation/dft.py
@@ -11,9 +11,6 @@ from math import ceil
 from warnings import warn
 from ..preprocessing import StandardScaler
 
-import sklearn
-SKLEARN_VERSION = sklearn.__version__
-
 
 class DiscreteFourierTransform(BaseEstimator, TransformerMixin):
     """Discrete Fourier Transform.
@@ -131,10 +128,7 @@ class DiscreteFourierTransform(BaseEstimator, TransformerMixin):
             The selected Fourier coefficients for each sample.
 
         """
-        if SKLEARN_VERSION >= '0.22':
-            check_is_fitted(self)
-        else:
-            check_is_fitted(self, 'support_')
+        check_is_fitted(self, 'support_')
         X = check_array(X, dtype='float64')
         n_samples, n_timestamps = X.shape
 

--- a/pyts/approximation/mcb.py
+++ b/pyts/approximation/mcb.py
@@ -11,9 +11,6 @@ from sklearn.tree import DecisionTreeClassifier
 from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
 from sklearn.utils.multiclass import check_classification_targets
 
-import sklearn
-SKLEARN_VERSION = sklearn.__version__
-
 
 @njit()
 def _uniform_bins(timestamp_min, timestamp_max, n_timestamps, n_bins):
@@ -148,10 +145,7 @@ class MultipleCoefficientBinning(BaseEstimator, TransformerMixin):
             Binned data.
 
         """
-        if SKLEARN_VERSION >= '0.22':
-            check_is_fitted(self)
-        else:
-            check_is_fitted(self, 'bin_edges_')
+        check_is_fitted(self, 'bin_edges_')
         X = check_array(X, dtype='float64')
         self._check_consistent_lengths(X)
         indices = _digitize(X, self.bin_edges_)

--- a/pyts/approximation/sfa.py
+++ b/pyts/approximation/sfa.py
@@ -9,9 +9,6 @@ from sklearn.utils.validation import check_is_fitted
 from .dft import DiscreteFourierTransform
 from .mcb import MultipleCoefficientBinning
 
-import sklearn
-SKLEARN_VERSION = sklearn.__version__
-
 
 class SymbolicFourierApproximation(BaseEstimator, TransformerMixin):
     """Symbolic Fourier Approximation.
@@ -143,10 +140,7 @@ class SymbolicFourierApproximation(BaseEstimator, TransformerMixin):
             Transformed data.
 
         """
-        if SKLEARN_VERSION >= '0.22':
-            check_is_fitted(self)
-        else:
-            check_is_fitted(self, ['support_', 'bin_edges_'])
+        check_is_fitted(self, ['support_', 'bin_edges_'])
         return self._pipeline.transform(X)
 
     def fit_transform(self, X, y=None):

--- a/pyts/classification/bossvs.py
+++ b/pyts/classification/bossvs.py
@@ -14,9 +14,6 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from ..approximation import SymbolicFourierApproximation
 from ..utils.utils import _windowed_view
 
-import sklearn
-SKLEARN_VERSION = sklearn.__version__
-
 
 class BOSSVS(BaseEstimator, ClassifierMixin):
     """Bag-of-SFA Symbols in Vector Space.
@@ -226,10 +223,7 @@ class BOSSVS(BaseEstimator, ClassifierMixin):
             Cosine similarity between the document-term matrix and X.
 
         """
-        if SKLEARN_VERSION >= '0.22':
-            check_is_fitted(self)
-        else:
-            check_is_fitted(self, ['vocabulary_', 'tfidf_', 'idf_', '_tfidf'])
+        check_is_fitted(self, ['vocabulary_', 'tfidf_', 'idf_', '_tfidf'])
         X = check_array(X, dtype='float64')
         n_samples, n_timestamps = X.shape
 

--- a/pyts/classification/knn.py
+++ b/pyts/classification/knn.py
@@ -10,9 +10,6 @@ from sklearn.utils.validation import check_X_y, check_is_fitted
 from ..metrics import (boss, dtw, dtw_classic, dtw_region, dtw_fast,
                        dtw_multiscale, sakoe_chiba_band, itakura_parallelogram)
 
-import sklearn
-SKLEARN_VERSION = sklearn.__version__
-
 
 class KNeighborsClassifier(BaseEstimator, ClassifierMixin):
     """k-nearest neighbors classifier.
@@ -221,10 +218,7 @@ class KNeighborsClassifier(BaseEstimator, ClassifierMixin):
             Probability estimates.
 
         """
-        if SKLEARN_VERSION >= '0.22':
-            check_is_fitted(self)
-        else:
-            check_is_fitted(self, '_clf')
+        check_is_fitted(self, '_clf')
         return self._clf.predict_proba(X)
 
     def predict(self, X):
@@ -241,8 +235,5 @@ class KNeighborsClassifier(BaseEstimator, ClassifierMixin):
             Class labels for each data sample.
 
         """
-        if SKLEARN_VERSION >= '0.22':
-            check_is_fitted(self)
-        else:
-            check_is_fitted(self, '_clf')
+        check_is_fitted(self, '_clf')
         return self._clf.predict(X)

--- a/pyts/classification/saxvsm.py
+++ b/pyts/classification/saxvsm.py
@@ -13,9 +13,6 @@ from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
 from ..bag_of_words import BagOfWords
 from ..approximation import SymbolicAggregateApproximation
 
-import sklearn
-SKLEARN_VERSION = sklearn.__version__
-
 
 class SAXVSM(BaseEstimator, ClassifierMixin):
     """Classifier based on SAX-VSM representation and tf-idf statistics.
@@ -180,11 +177,8 @@ class SAXVSM(BaseEstimator, ClassifierMixin):
             osine similarity between the document-term matrix and X.
 
         """
-        if SKLEARN_VERSION >= '0.22':
-            check_is_fitted(self)
-        else:
-            check_is_fitted(self, ['vocabulary_', 'tfidf_', 'idf_',
-                                   '_tfidf', 'classes_'])
+        check_is_fitted(self, ['vocabulary_', 'tfidf_', 'idf_',
+                               '_tfidf', 'classes_'])
         X_sax = self._sax.transform(X)
         X_bow = self._bow.transform(X_sax)
         vectorizer = CountVectorizer(vocabulary=self._tfidf.vocabulary_)

--- a/pyts/multivariate/classification/multivariate.py
+++ b/pyts/multivariate/classification/multivariate.py
@@ -10,9 +10,6 @@ from sklearn.preprocessing import LabelEncoder
 from sklearn.utils.validation import check_is_fitted
 from ..utils import check_3d_array
 
-import sklearn
-SKLEARN_VERSION = sklearn.__version__
-
 
 @njit()
 def _hard_vote(y_pred, weights):
@@ -114,10 +111,7 @@ class MultivariateClassifier(BaseEstimator, ClassifierMixin):
 
         """
         X = check_3d_array(X)
-        if SKLEARN_VERSION >= '0.22':
-            check_is_fitted(self)
-        else:
-            check_is_fitted(self, 'estimators_')
+        check_is_fitted(self, 'estimators_')
         n_samples, n_features, _ = X.shape
 
         y_pred = np.empty((n_samples, n_features))

--- a/pyts/multivariate/transformation/multivariate.py
+++ b/pyts/multivariate/transformation/multivariate.py
@@ -9,9 +9,6 @@ from sklearn.base import BaseEstimator, TransformerMixin, clone
 from sklearn.utils.validation import check_is_fitted
 from ..utils import check_3d_array
 
-import sklearn
-SKLEARN_VERSION = sklearn.__version__
-
 
 class MultivariateTransformer(BaseEstimator, TransformerMixin):
     r"""Transformer for multivariate time series.
@@ -95,10 +92,7 @@ class MultivariateTransformer(BaseEstimator, TransformerMixin):
         """
         X = check_3d_array(X)
         n_samples, _, _ = X.shape
-        if SKLEARN_VERSION >= '0.22':
-            check_is_fitted(self)
-        else:
-            check_is_fitted(self, 'estimators_')
+        check_is_fitted(self, 'estimators_')
 
         X_transformed = [transformer.transform(X[:, i, :])
                          for i, transformer in enumerate(self.estimators_)]

--- a/pyts/multivariate/transformation/weasel_muse.py
+++ b/pyts/multivariate/transformation/weasel_muse.py
@@ -12,9 +12,6 @@ from sklearn.utils.validation import check_is_fitted
 from ...transformation import WEASEL
 from ..utils import check_3d_array
 
-import sklearn
-SKLEARN_VERSION = sklearn.__version__
-
 
 class WEASELMUSE(BaseEstimator, TransformerMixin):
     r"""WEASEL+MUSE algorithm.
@@ -179,10 +176,7 @@ class WEASELMUSE(BaseEstimator, TransformerMixin):
             Document-term matrix with relevant learned features only.
 
         """
-        if SKLEARN_VERSION >= '0.22':
-            check_is_fitted(self)
-        else:
-            check_is_fitted(self, 'vocabulary_')
+        check_is_fitted(self, 'vocabulary_')
         X = check_3d_array(X)
         n_samples, _, _ = X.shape
         X_diff = np.abs(np.diff(X))

--- a/pyts/transformation/boss.py
+++ b/pyts/transformation/boss.py
@@ -13,9 +13,6 @@ from sklearn.utils.multiclass import check_classification_targets
 from ..approximation import SymbolicFourierApproximation
 from ..utils.utils import _windowed_view
 
-import sklearn
-SKLEARN_VERSION = sklearn.__version__
-
 
 class BOSS(BaseEstimator, TransformerMixin):
     """Bag of Symbolic Fourier Approximation Symbols.
@@ -197,10 +194,7 @@ class BOSS(BaseEstimator, TransformerMixin):
             Document-term matrix.
 
         """
-        if SKLEARN_VERSION >= '0.22':
-            check_is_fitted(self)
-        else:
-            check_is_fitted(self, ['_sfa', '_vectorizer', 'vocabulary_'])
+        check_is_fitted(self, ['_sfa', '_vectorizer', 'vocabulary_'])
         X = check_array(X)
         n_samples, n_timestamps = X.shape
 

--- a/pyts/transformation/shapelet_transform.py
+++ b/pyts/transformation/shapelet_transform.py
@@ -11,9 +11,6 @@ from sklearn.utils.validation import (check_array, check_is_fitted,
                                       check_random_state, check_X_y)
 from ..utils.utils import _windowed_view
 
-import sklearn
-SKLEARN_VERSION = sklearn.__version__
-
 
 @njit()
 def _extract_all_shapelets_raw(x, window_sizes, window_steps, n_timestamps):
@@ -340,10 +337,7 @@ class ShapeletTransform(BaseEstimator, TransformerMixin):
             Distances between the selected shapelets and the samples.
 
         """
-        if SKLEARN_VERSION >= '0.22':
-            check_is_fitted(self)
-        else:
-            check_is_fitted(self, ['shapelets_', 'indices_', 'scores_'])
+        check_is_fitted(self, ['shapelets_', 'indices_', 'scores_'])
         X = check_array(X, dtype='float64')
         return self._transform(X)
 

--- a/pyts/transformation/weasel.py
+++ b/pyts/transformation/weasel.py
@@ -13,9 +13,6 @@ from sklearn.feature_selection import chi2
 from ..approximation import SymbolicFourierApproximation
 from ..utils.utils import _windowed_view
 
-import sklearn
-SKLEARN_VERSION = sklearn.__version__
-
 
 class WEASEL(BaseEstimator, TransformerMixin):
     """Word ExtrAction for time SEries cLassification.
@@ -201,11 +198,8 @@ class WEASEL(BaseEstimator, TransformerMixin):
             Document-term matrix with relevant features only.
 
         """
-        if SKLEARN_VERSION >= '0.22':
-            check_is_fitted(self)
-        else:
-            check_is_fitted(self, ['_relevant_features_list', '_sfa_list',
-                                   '_vectorizer_list', 'vocabulary_'])
+        check_is_fitted(self, ['_relevant_features_list', '_sfa_list',
+                               '_vectorizer_list', 'vocabulary_'])
 
         X = check_array(X, dtype='float64')
         n_samples, n_timestamps = X.shape


### PR DESCRIPTION
This PR removes the `if else` loops for `check_is_fitted` since the behavior does not depend on the version of scikit-learn anymore (which was not the case in the dev version for 0.22).