### PR TITLE
Add LearningShapelets algorithm in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ in time series classification.
 - `classification`: This module provides implementations of algorithms that
 can classify time series. Implemented algorithms are
 [KNeighborsClassifier](https://pyts.readthedocs.io/en/latest/generated/pyts.classification.KNeighborsClassifier.html#),
+[LearningShapelets](https://pyts.readthedocs.io/en/latest/generated/pyts.classification.LearningShapelets.html#),
 [SAXVSM](https://pyts.readthedocs.io/en/latest/generated/pyts.classification.SAXVSM.html#) and
 [BOSSVS](https://pyts.readthedocs.io/en/latest/generated/pyts.classification.BOSSVS.html#).
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -19,10 +19,10 @@ Full API documentation of the *pyts* Python package.
    :toctree: generated/
    :template: class.rst
 
-   approximation.PiecewiseAggregateApproximation
-   approximation.SymbolicAggregateApproximation
    approximation.DiscreteFourierTransform
    approximation.MultipleCoefficientBinning
+   approximation.PiecewiseAggregateApproximation
+   approximation.SymbolicAggregateApproximation
    approximation.SymbolicFourierApproximation
 
 
@@ -55,9 +55,10 @@ Full API documentation of the *pyts* Python package.
   :toctree: generated/
   :template: class.rst
 
-  classification.KNeighborsClassifier
-  classification.SAXVSM
   classification.BOSSVS
+  classification.KNeighborsClassifier
+  classification.LearningShapelets
+  classification.SAXVSM
 
 
 :mod:`pyts.datasets`: Dataset loading utilities
@@ -115,9 +116,9 @@ Full API documentation of the *pyts* Python package.
   :toctree: generated/
   :template: class.rst
 
-  image.RecurrencePlot
   image.GramianAngularField
   image.MarkovTransitionField
+  image.RecurrencePlot
 
 
 :mod:`pyts.metrics`: Metrics
@@ -136,11 +137,11 @@ Full API documentation of the *pyts* Python package.
   metrics.boss
   metrics.dtw
   metrics.dtw_classic
-  metrics.dtw_region
-  metrics.dtw_sakoechiba
+  metrics.dtw_fast
   metrics.dtw_itakura
   metrics.dtw_multiscale
-  metrics.dtw_fast
+  metrics.dtw_region
+  metrics.dtw_sakoechiba
   metrics.itakura_parallelogram
   metrics.sakoe_chiba_band
   metrics.show_options
@@ -219,10 +220,10 @@ Scaling
   :toctree: generated/
   :template: class.rst
 
-  preprocessing.StandardScaler
-  preprocessing.MinMaxScaler
   preprocessing.MaxAbsScaler
+  preprocessing.MinMaxScaler
   preprocessing.RobustScaler
+  preprocessing.StandardScaler
 
 Transformation
 --------------

--- a/doc/modules/classification.rst
+++ b/doc/modules/classification.rst
@@ -74,6 +74,7 @@ is the class yielding the highest cosine similarity.
      Classification Using SAX and Vector Space Model". International
      Conference on Data Mining, 13, 1175-1180 (2013).
 
+
 BOSSVS
 ------
 
@@ -104,3 +105,39 @@ the words are generated with the :ref:`approximation_sfa` algorithm.
 
   * P. Schäfer, "Scalable Time Series Classification". Data Mining and
     Knowledge Discovery, 30(5), 1273-1298 (2016).
+
+
+LearningShapelets
+-----------------
+
+:class:`LearningShapelets` is a shapelet-based classifier.
+A shapelet is defined as a contiguous subsequence of a time series.
+The distance between a shapelet and a time series is defined as the minimum
+of the distances between this shapelet and all the shapelets of identical
+length extracted from this time series.
+This estimator consists of two steps: computing the distances between the
+shapelets and the time series, then computing a logistic regression using
+these distances as features. This algorithm learns the shapelets as well as
+the coefficients of the logistic regression.
+
+.. figure:: ../auto_examples/classification/images/sphx_glr_plot_learning_shapelets_001.png
+   :target: ../auto_examples/classification/plot_learning_shapelets.html
+   :align: center
+   :scale: 60%
+
+.. code-block:: python
+
+    >>> from pyts.classification import LearningShapelets
+    >>> from pyts.datasets import load_gunpoint
+    >>> X_train, X_test, y_train, y_test = load_gunpoint(return_X_y=True)
+    >>> clf = LearningShapelets(random_state=42, tol=0.01)
+    >>> clf.fit(X_train, y_train)
+    LearningShapelets(...)
+    >>> clf.score(X_test, y_test)
+    0.766...
+
+.. topic:: References
+
+  * J. Grabocka, N. Schilling, M. Wistuba and L. Schmidt-Thieme,
+    "Learning Time-Series Shapelets". International Conference on Data
+    Mining, 14, 392-401 (2014).

--- a/examples/classification/plot_learning_shapelets.py
+++ b/examples/classification/plot_learning_shapelets.py
@@ -1,0 +1,58 @@
+"""
+==============================
+Learning Time-Series Shapelets
+==============================
+
+This example illustrates what the LearningShapelets algorithm learns in the
+training phase.
+A shapelet is defined as a contiguous subsequence of a time series.
+The distance between a shapelet and a time series is defined as the minimum
+of the distances between this shapelet and all the shapelets of identical
+length extracted from this time series.
+This estimator consists of two steps: computing the distances between the
+shapelets and the time series, then computing a logistic regression using
+these distances as features. This algorithm learns the shapelets as well as
+the coefficients of the logistic regression.
+
+This example highlights two learned shapelets and the distances between the
+time series and both shapelets. Note that the tolerance parameter is set to a
+high value so that the algorithm converges early (and the example runs faster).
+It is implemented as :class:`pyts.classification.LearningShapelets`.
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+from pyts.classification import LearningShapelets
+from pyts.datasets import load_gunpoint
+from pyts.utils import windowed_view
+
+# Load the data set and fit the classifier
+X, _, y, _ = load_gunpoint(return_X_y=True)
+clf = LearningShapelets(random_state=42, tol=0.01)
+clf.fit(X, y)
+
+# Select two shapelets
+shapelets = np.asarray([clf.shapelets_[0, -9], clf.shapelets_[0, -12]])
+
+# Derive the distances between the time series and the shapelets
+shapelet_size = shapelets.shape[1]
+X_window = windowed_view(X, window_size=shapelet_size, window_step=1)
+X_dist = np.mean(
+    (X_window[:, :, None] - shapelets[None, :]) ** 2, axis=3).min(axis=1)
+
+plt.figure(figsize=(14, 4))
+
+# Plot the two shapelets
+plt.subplot(1, 2, 1)
+plt.plot(shapelets[0])
+plt.plot(shapelets[1])
+plt.title('Two learned shapelets', fontsize=14)
+
+# Plot the distances
+plt.subplot(1, 2, 2)
+for color, label in zip('br', (1, 2)):
+    plt.scatter(X_dist[y == label, 0], X_dist[y == label, 1],
+                c=color, label='Class {}'.format(label))
+plt.title('Distances between the time series and both shapelets',
+          fontsize=14)
+plt.legend()
+plt.show()

--- a/pyts/classification/learning_shapelets.py
+++ b/pyts/classification/learning_shapelets.py
@@ -401,9 +401,6 @@ class CrossEntropyLearningShapelets(BaseEstimator, ClassifierMixin):
            "Learning Time-Series Shapelets". International Conference on Data
            Mining, 14, 392-401 (2014).
 
-    Examples
-    --------
-
     """
 
     def __init__(self, n_shapelets_per_size=0.2, min_shapelet_length=0.1,
@@ -940,13 +937,15 @@ class LearningShapelets(BaseEstimator, ClassifierMixin):
     Examples
     --------
     >>> from pyts.classification import LearningShapelets
-    >>> from pyts.datasets import load_gunpoint
-    >>> X, _, y, _ = load_gunpoint(return_X_y=True)
+    >>> X = [[1, 2, 2, 1, 2, 3, 2],
+    ...      [0, 2, 0, 2, 0, 2, 3],
+    ...      [0, 1, 2, 2, 1, 2, 2]]
+    >>> y = [0, 1, 0]
     >>> clf = LearningShapelets(random_state=42, tol=0.01)
     >>> clf.fit(X, y)
     LearningShapelets(...)
     >>> clf.coef_.shape
-    (1, 90)
+    (1, 6)
 
     """
 

--- a/pyts/classification/learning_shapelets.py
+++ b/pyts/classification/learning_shapelets.py
@@ -314,13 +314,13 @@ class CrossEntropyLearningShapelets(BaseEstimator, ClassifierMixin):
         Number of shapelets per size. If float, it represents
         a fraction of the number of timestamps and the number
         of shapelets per size is equal to
-        ``ceil(n_shapelets_per_size * n_timestamps).``
+        ``ceil(n_shapelets_per_size * n_timestamps)``.
 
     min_shapelet_length : int or float (default = 0.1)
         Minimum length of the shapelets. If float, it represents
         a fraction of the number of timestamps and the minimum
         length of the shapelets per size is equal to
-        ``ceil(min_shapelet_length * n_timestamps).``
+        ``ceil(min_shapelet_length * n_timestamps)``.
 
     shapelet_scale : int (default = 3)
         The different scales for the lengths of the shapelets.
@@ -814,7 +814,12 @@ class CrossEntropyLearningShapelets(BaseEstimator, ClassifierMixin):
 
 
 class LearningShapelets(BaseEstimator, ClassifierMixin):
-    """Learning Shapelets algorithm for binary classification.
+    """Learning Shapelets algorithm.
+
+    This estimator consists of two steps: computing the distances between the
+    shapelets and the time series, then computing a logistic regression using
+    these distances as features. This algorithm learns the shapelets as well as
+    the coefficients of the logistic regression.
 
     Parameters
     ----------
@@ -822,13 +827,13 @@ class LearningShapelets(BaseEstimator, ClassifierMixin):
         Number of shapelets per size. If float, it represents
         a fraction of the number of timestamps and the number
         of shapelets per size is equal to
-        ``ceil(n_shapelets_per_size * n_timestamps).``
+        ``ceil(n_shapelets_per_size * n_timestamps)``.
 
     min_shapelet_length : int or float (default = 0.1)
         Minimum length of the shapelets. If float, it represents
         a fraction of the number of timestamps and the minimum
         length of the shapelets per size is equal to
-        ``ceil(min_shapelet_length * n_timestamps).``
+        ``ceil(min_shapelet_length * n_timestamps)``.
 
     shapelet_scale : int (default = 3)
         The different scales for the lengths of the shapelets.
@@ -934,6 +939,14 @@ class LearningShapelets(BaseEstimator, ClassifierMixin):
 
     Examples
     --------
+    >>> from pyts.classification import LearningShapelets
+    >>> from pyts.datasets import load_gunpoint
+    >>> X, _, y, _ = load_gunpoint(return_X_y=True)
+    >>> clf = LearningShapelets(random_state=42, tol=0.01)
+    >>> clf.fit(X, y)
+    LearningShapelets(...)
+    >>> clf.coef_.shape
+    (1, 90)
 
     """
 


### PR DESCRIPTION
This PR adds the LearningShapelets algorithm in the documentation:
* in `doc/api.rst`
* in `doc/modules/classification.rst`
* in `examples/classification/plot_learning_shapelets.py`
* in `README.md`