### PR TITLE
Fix issues in setup.py and in links to the documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ for a history of notable changes to pyts.
 
 The development of this package is in line with the one of the scikit-learn
 community. Fore more information about our contributing guidelines, please
-refer to the [documentation](https://pyts.readthedocs.io/en/latest/contribute.html).
+refer to the [documentation](https://pyts.readthedocs.io/en/stable/contribute.html).
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ directory using pytest:
 
 ### Changelog
 
-See the [changelog](https://pyts.readthedocs.io/en/latest/changelog.html)
+See the [changelog](https://pyts.readthedocs.io/en/stable/changelog.html)
 for a history of notable changes to pyts.
 
 ### Development
@@ -76,6 +76,10 @@ For more information, please have a look at the
 [HTML documentation available via ReadTheDocs](https://pyts.readthedocs.io/).
 
 ### Implemented features
+
+**Note: the content described in this section corresponds to the master branch,
+not the latest released version. You may have to install the latest version
+to use some of these features.**
 
 pyts consists of the following modules:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://dev.azure.com/johannfaouzi0034/johannfaouzi/_apis/build/status/johannfaouzi.pyts?branchName=master)](https://dev.azure.com/johannfaouzi0034/johannfaouzi/_build/latest?definitionId=1&branchName=master)
-[![Documentation Status](https://readthedocs.org/projects/pyts/badge/?version=latest)](https://pyts.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/pyts/badge/?version=latest)](https://pyts.readthedocs.io/)
 [![Codecov](https://codecov.io/gh/johannfaouzi/pyts/branch/master/graph/badge.svg)](https://codecov.io/gh/johannfaouzi/pyts)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyts.svg)](https://img.shields.io/pypi/pyversions/pyts.svg)
 [![PyPI version](https://badge.fury.io/py/pyts.svg)](https://badge.fury.io/py/pyts)
@@ -73,7 +73,7 @@ refer to the [documentation](https://pyts.readthedocs.io/en/latest/contribute.ht
 
 The section below gives some information about the implemented algorithms in pyts.
 For more information, please have a look at the
-[HTML documentation available via ReadTheDocs](https://pyts.readthedocs.io/en/latest/).
+[HTML documentation available via ReadTheDocs](https://pyts.readthedocs.io/).
 
 ### Implemented features
 

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,10 @@ URL = 'https://github.com/johannfaouzi/pyts'
 LICENSE = 'new BSD'
 DOWNLOAD_URL = 'https://github.com/johannfaouzi/pyts'
 VERSION = pyts.__version__
-INSTALL_REQUIRES = ['numpy>=1.15.4'
-                    'scipy>=1.3.0'
-                    'scikit-learn>=0.22.1'
-                    'joblib>=0.12'
+INSTALL_REQUIRES = ['numpy>=1.15.4',
+                    'scipy>=1.3.0',
+                    'scikit-learn>=0.22.1',
+                    'joblib>=0.12',
                     'numba==0.46.0']
 CLASSIFIERS = ['Development Status :: 3 - Alpha',
                'Intended Audience :: Science/Research',
@@ -39,7 +39,7 @@ EXTRAS_REQUIRE = {
         'pytest',
         'pytest-cov'],
     'docs': [
-        'sphinx==1.8.2',
+        'sphinx==1.8.5',
         'sphinx-gallery',
         'numpydoc',
         'matplotlib'


### PR DESCRIPTION
Fixes #65 

This small PR:
* adds missing commas in `INSTALL_REQUIRES` list in `setup.py`
* changes the links to the documentation to the stable version for the first sections in `README.md`
* adds a note in the `Implemented features` section in `README.md` to mention that this description corresponds to the master branch, not the latest released version.