### PR TITLE
Bug in _blurred_path_region

### DIFF
--- a/pyts/metrics/dtw.py
+++ b/pyts/metrics/dtw.py
@@ -905,10 +905,10 @@ def _blurred_path_region(n_timestamps_1, n_timestamps_2, resolution_level,
     for i in range(1, radius + 1):
         start = path_length * (i - 1)
         end = path_length * i
-        path_up[0, start: end] += i
-        path_down[0, start: end] -= i
-        path_left[1, start: end] -= i
-        path_right[1, start: end] += i
+        path_up[0, start: end] += radius
+        path_down[0, start: end] -= radius
+        path_left[1, start: end] -= radius
+        path_right[1, start: end] += radius
 
     path_radius = np.c_[path, path_up, path_down, path_left, path_right]
     path_radius[0] = np.clip(path_radius[0], 0, n_timestamps_reduced_1 - 1)


### PR DESCRIPTION
I think I found a bug in _blurred_path_region function.
path_up, path_down, path_left and path_right should be incremented by radius instead of i. It isn't obvious from your example at https://pyts.readthedocs.io/en/stable/auto_examples/metrics/plot_dtw.html#sphx-glr-auto-examples-metrics-plot-dtw-py, but I think for the region to remain constant it shouldn't get larger with i in the for cycle. I hope it makes sense. Regards, Stepan.