### PR TITLE
Fix SAXVSM with constant subsequences

### DIFF
--- a/examples/image/plot_single_gaf.py
+++ b/examples/image/plot_single_gaf.py
@@ -4,9 +4,9 @@ Single Gramian angular field
 ============================
 
 A Gramian angular field is an image obtained from a time series, representing
-some kind of temporal correlation between the values at each time point. Two
-methods are available: Gramian angular summation field and Gramian angular
-difference field.
+some kind of temporal correlation between each pair of values from the time
+series. Two methods are available: Gramian angular summation field and Gramian
+angular difference field.
 It is implemented as :class:`pyts.image.GramianAngularField`.
 
 In this example, the considered time series is the sequence of the sine

--- a/pyts/approximation/sax.py
+++ b/pyts/approximation/sax.py
@@ -27,6 +27,11 @@ class SymbolicAggregateApproximation(BaseEstimator,
         - 'quantile': All bins in each sample have the same number of points
         - 'normal': Bin edges are quantiles from a standard normal distribution
 
+    raise_warning : bool (default = True)
+        If True, a warning is raised when the number of bins is smaller for
+        at least one sample. In this case, you should consider decreasing the
+        number of bins or removing these samples.
+
     alphabet : None, 'ordinal' or array-like, shape = (n_bins,)
         Alphabet to use. If None, the first `n_bins` letters of the Latin
         alphabet are used. If 'ordinal', integers are used.
@@ -49,9 +54,11 @@ class SymbolicAggregateApproximation(BaseEstimator,
 
     """
 
-    def __init__(self, n_bins=4, strategy='quantile', alphabet=None):
+    def __init__(self, n_bins=4, strategy='quantile', raise_warning=True,
+                 alphabet=None):
         self.n_bins = n_bins
         self.strategy = strategy
+        self.raise_warning = raise_warning
         self.alphabet = alphabet
 
     def fit(self, X=None, y=None):
@@ -85,7 +92,9 @@ class SymbolicAggregateApproximation(BaseEstimator,
         n_timestamps = X.shape[1]
         alphabet = self._check_params(n_timestamps)
         discretizer = KBinsDiscretizer(
-            n_bins=self.n_bins, strategy=self.strategy)
+            n_bins=self.n_bins, strategy=self.strategy,
+            raise_warning=self.raise_warning
+        )
         indices = discretizer.fit_transform(X)
         if isinstance(alphabet, str):
             return indices

--- a/pyts/bag_of_words/tests/test_bow.py
+++ b/pyts/bag_of_words/tests/test_bow.py
@@ -67,7 +67,8 @@ def test_actual_results_word_extractor(params, arr_desired):
 
 # ######################### Tests for BagOfWords #########################
 
-X_bow = np.arange(20).reshape(2, 10)
+X_bow = np.arange(30).reshape(3, 10)
+X_bow[2, :8] = 20
 
 
 @pytest.mark.parametrize(
@@ -123,6 +124,14 @@ X_bow = np.arange(20).reshape(2, 10)
       "If 'window_step' is a float, it must be greater than 0 and lower "
       "than or equal to 1 (got {0}).".format(2.)),
 
+     ({'window_size': 6, 'word_size': 4, 'n_bins': 2, 'threshold_std': '-1'},
+      TypeError,
+      "'threshold_std' must be a float."),
+
+     ({'window_size': 6, 'word_size': 4, 'n_bins': 2, 'threshold_std': -1.},
+      ValueError,
+      "'threshold_std' must be non-negative (got -1.0)."),
+
      ({'window_size': 6, 'word_size': 4, 'n_bins': 2, 'alphabet': 'whoops'},
       TypeError,
       "'alphabet' must be None or array-like with shape (n_bins,) "
@@ -136,37 +145,45 @@ def test_parameter_check_bag_of_words(params, error, err_msg):
     """Test parameter validation."""
     bow = BagOfWords(**params)
     with pytest.raises(error, match=re.escape(err_msg)):
+        print(bow.get_params()['threshold_std'])
         bow.transform(X_bow)
 
 
 @pytest.mark.parametrize(
-    'params, arr_desired',
-    [({'window_size': 6, 'word_size': 4}, ['abcd', 'abcd']),
+    'params, X, arr_desired',
+    [({'window_size': 8, 'word_size': 4}, X_bow,
+      ['abcd', 'abcd', 'bbbb bbbd']),
 
-     ({'window_size': 6, 'word_size': 4, 'numerosity_reduction': False},
-      ['abcd abcd abcd abcd abcd', 'abcd abcd abcd abcd abcd']),
+     ({'window_size': 8, 'word_size': 4, 'numerosity_reduction': False},
+      X_bow, ['abcd abcd abcd', 'abcd abcd abcd', 'bbbb bbbd bbbd']),
 
-     ({'window_size': 6, 'word_size': 4, 'alphabet': ['y', 'o', 'l', 'o']},
-      ['yolo', 'yolo']),
+     ({'window_size': 8, 'word_size': 4, 'strategy': 'uniform'}, X_bow,
+      ['abcd', 'abcd', 'aaaa aaad']),
 
-     ({'window_size': 0.5, 'word_size': 4}, ['abcd', 'abcd']),
+     ({'window_size': 8, 'word_size': 4, 'strategy': 'quantile'}, X_bow,
+      ['abcd', 'abcd', 'aaaa aaac']),
+
+     ({'window_size': 8, 'word_size': 4, 'alphabet': ['y', 'o', 'l', 'o']},
+      X_bow, ['yolo', 'yolo', 'oooo']),
+
+     ({'window_size': 0.5, 'word_size': 4}, X_bow[:2], ['abcd', 'abcd']),
 
      ({'window_size': 4, 'word_size': 1., 'numerosity_reduction': False},
-      ['abcd abcd abcd abcd abcd abcd abcd',
-       'abcd abcd abcd abcd abcd abcd abcd']),
+      X_bow[:2], ['abcd abcd abcd abcd abcd abcd abcd',
+                  'abcd abcd abcd abcd abcd abcd abcd']),
 
      ({'window_size': 4, 'word_size': 4, 'window_step': 2,
        'numerosity_reduction': False},
-      ['abcd abcd abcd abcd', 'abcd abcd abcd abcd']),
+      X_bow[:2], ['abcd abcd abcd abcd', 'abcd abcd abcd abcd']),
 
      ({'window_size': 4, 'word_size': 4, 'window_step': 0.2,
        'numerosity_reduction': False},
-      ['abcd abcd abcd abcd', 'abcd abcd abcd abcd']),
+      X_bow[:2], ['abcd abcd abcd abcd', 'abcd abcd abcd abcd']),
 
      ({'window_size': 4, 'word_size': 4, 'window_step': 0.5},
-      ['abcd', 'abcd'])]
+      X_bow[:2], ['abcd', 'abcd'])]
 )
-def test_actual_results_bag_of_words(params, arr_desired):
+def test_actual_results_bag_of_words(params, X, arr_desired):
     """Test that the actual results are the expected ones."""
-    arr_actual = BagOfWords(**params).fit_transform(X_bow)
+    arr_actual = BagOfWords(**params).fit_transform(X)
     np.testing.assert_array_equal(arr_actual, arr_desired)

--- a/pyts/classification/saxvsm.py
+++ b/pyts/classification/saxvsm.py
@@ -55,6 +55,11 @@ class SAXVSM(BaseEstimator, UnivariateClassifierMixin):
         sliding window will be computed as
         ``ceil(window_step * n_timestamps)``.
 
+    threshold_std: float (default = 0.01)
+        Threshold used to determine whether a subsequence is standardized.
+        Subsequences whose standard deviations are lower than this threshold
+        are not standardized.
+
     norm_mean : bool (default = True)
         If True, center each subseries before scaling.
 
@@ -112,20 +117,22 @@ class SAXVSM(BaseEstimator, UnivariateClassifierMixin):
     >>> clf.fit(X_train, y_train)
     SAXVSM(...)
     >>> clf.score(X_test, y_test)
-    0.9933...
+    1.0
 
     """
 
     def __init__(self, window_size=0.5, word_size=0.5, n_bins=4,
                  strategy='normal', numerosity_reduction=True, window_step=1,
-                 norm_mean=True, norm_std=True, use_idf=True, smooth_idf=False,
-                 sublinear_tf=True, overlapping=True, alphabet=None):
+                 threshold_std=0.01, norm_mean=True, norm_std=True,
+                 use_idf=True, smooth_idf=False, sublinear_tf=True,
+                 overlapping=True, alphabet=None):
         self.window_size = window_size
         self.word_size = word_size
         self.n_bins = n_bins
         self.strategy = strategy
         self.numerosity_reduction = numerosity_reduction
         self.window_step = window_step
+        self.threshold_std = threshold_std
         self.norm_mean = norm_mean
         self.norm_std = norm_std
         self.use_idf = use_idf
@@ -162,9 +169,9 @@ class SAXVSM(BaseEstimator, UnivariateClassifierMixin):
             window_size=self.window_size, word_size=self.word_size,
             n_bins=self.n_bins, strategy=self.strategy,
             numerosity_reduction=self.numerosity_reduction,
-            window_step=self.window_step, norm_mean=self.norm_mean,
-            norm_std=self.norm_std, overlapping=self.overlapping,
-            alphabet=self.alphabet
+            window_step=self.window_step, threshold_std=self.threshold_std,
+            norm_mean=self.norm_mean, norm_std=self.norm_std,
+            overlapping=self.overlapping, alphabet=self.alphabet
         )
         X_bow = bow.fit_transform(X)
 

--- a/pyts/preprocessing/discretizer.py
+++ b/pyts/preprocessing/discretizer.py
@@ -5,6 +5,7 @@
 
 import numpy as np
 from numba import njit, prange
+from numba.typed import List
 from scipy.stats import norm
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_array
@@ -37,9 +38,17 @@ def _digitize_2d(X, bins, n_samples, n_timestamps):
     return X_digit
 
 
+@njit
+def _reshape_with_nan(X, n_samples, lengths, max_length):
+    X_fill = np.full((n_samples, max_length), np.nan)
+    for i in prange(n_samples):
+        X_fill[i, :lengths[i]] = X[i]
+    return X_fill
+
+
 def _digitize(X, bins):
     n_samples, n_timestamps = X.shape
-    if isinstance(bins, tuple):
+    if isinstance(bins, List):
         X_binned = _digitize_2d(X, bins, n_samples, n_timestamps)
     else:
         if bins.ndim == 1:
@@ -66,6 +75,11 @@ class KBinsDiscretizer(BaseEstimator, UnivariateTransformerMixin):
         - 'quantile': All bins in each sample have the same number of points
         - 'normal': Bin edges are quantiles from a standard normal distribution
 
+    raise_warning : bool (default = True)
+        If True, a warning is raised when the number of bins is smaller for
+        at least one sample. In this case, you should consider decreasing the
+        number of bins or removing these samples.
+
     Examples
     --------
     >>> from pyts.preprocessing import KBinsDiscretizer
@@ -78,9 +92,10 @@ class KBinsDiscretizer(BaseEstimator, UnivariateTransformerMixin):
 
     """
 
-    def __init__(self, n_bins=5, strategy='quantile'):
+    def __init__(self, n_bins=5, strategy='quantile', raise_warning=True):
         self.n_bins = n_bins
         self.strategy = strategy
+        self.raise_warning = raise_warning
 
     def fit(self, X=None, y=None):
         """Pass.
@@ -142,26 +157,31 @@ class KBinsDiscretizer(BaseEstimator, UnivariateTransformerMixin):
 
     def _compute_bins(self, X, n_samples, n_bins, strategy):
         if strategy == 'normal':
-            bins_edges = norm.ppf(np.linspace(0, 1, self.n_bins + 1)[1:-1])
+            bin_edges = norm.ppf(np.linspace(0, 1, self.n_bins + 1)[1:-1])
         elif strategy == 'uniform':
             sample_min, sample_max = np.min(X, axis=1), np.max(X, axis=1)
-            bins_edges = _uniform_bins(
+            bin_edges = _uniform_bins(
                 sample_min, sample_max, n_samples, n_bins).T
         else:
-            bins_edges = np.percentile(
+            bin_edges = np.percentile(
                 X, np.linspace(0, 100, self.n_bins + 1)[1:-1], axis=1
-            )
-            mask = np.r_[
-                ~np.isclose(0, np.diff(bins_edges, axis=0), rtol=0, atol=1e-8),
-                np.full((1, n_samples), True)
+            ).T
+            mask = np.c_[
+                ~np.isclose(0, np.diff(bin_edges, axis=1), rtol=0, atol=1e-8),
+                np.full((n_samples, 1), True)
             ]
             if (self.n_bins > 2) and np.any(~mask):
                 samples = np.where(np.any(~mask, axis=0))[0]
-                warn("Some quantiles are equal. The number of bins will be "
-                     "smaller for sample {0}. Consider decreasing the number "
-                     "of bins or removing these samples.".format(samples))
-            bins_edges = np.asarray([bins_edges[:, i][mask[:, i]]
-                                     for i in range(n_samples)])
-            if bins_edges.ndim == 1:
-                bins_edges = tuple(bins_edges)
-        return bins_edges
+                if self.raise_warning:
+                    warn("Some quantiles are equal. The number of bins will "
+                         "be smaller for sample {0}. Consider decreasing the "
+                         "number of bins or removing these samples."
+                         .format(samples))
+                lengths = np.sum(mask, axis=1)
+                max_length = np.max(lengths)
+                bin_edges = List(
+                    [bin_edges[i][mask[i]] for i in range(n_samples)]
+                )
+                bin_edges = _reshape_with_nan(bin_edges, n_samples,
+                                              lengths, max_length)
+        return bin_edges

--- a/pyts/preprocessing/tests/test_discretizer.py
+++ b/pyts/preprocessing/tests/test_discretizer.py
@@ -4,9 +4,12 @@
 # License: BSD-3-Clause
 
 import numpy as np
+from numba.typed import List
 import pytest
 import re
-from pyts.preprocessing.discretizer import _uniform_bins, _digitize
+from pyts.preprocessing.discretizer import (
+    _uniform_bins, _digitize, _reshape_with_nan
+)
 from pyts.preprocessing import KBinsDiscretizer
 
 
@@ -41,6 +44,25 @@ def test_digitize(X, bins, arr_desired):
     """Test '_digitize' function."""
     X_float = np.asarray(X, dtype='float64')
     arr_actual = _digitize(X_float, bins)
+    np.testing.assert_array_equal(arr_actual, arr_desired)
+
+
+@pytest.mark.parametrize(
+    'params, arr_desired',
+    [({'X': List([np.array([2., 4., 8.]), np.array([3., 5.])]),
+       'n_samples':2, 'lengths': np.array([3, 2]), 'max_length': 3},
+      [[2, 4, 8], [3, 5, np.nan]]),
+
+     ({'X': List([np.array([2, 4, 8]), np.array([3]), np.array([5, 7])]),
+       'n_samples':3, 'lengths': np.array([3, 1, 2]), 'max_length': 3},
+      [[2, 4, 8], [3, np.nan, np.nan], [5, 7, np.nan]]),
+
+     ({'X': List([np.array([3]), np.array([2, 4, 8]), np.array([5, 7])]),
+       'n_samples':3, 'lengths': np.array([1, 3, 2]), 'max_length': 3},
+      [[3, np.nan, np.nan], [2, 4, 8], [5, 7, np.nan]])]
+)
+def testing_reshape_with_nan(params, arr_desired):
+    arr_actual = _reshape_with_nan(**params)
     np.testing.assert_array_equal(arr_actual, arr_desired)
 
 


### PR DESCRIPTION
This PR provides a better handling of subsequences with low standard deviation in SAXVSM:
* A `threshold_std` parameter is added to determine the subsequences that are standardized
* The bin edges used for such subsequences are computed over the whole time series (instead of the subsequence)
* A `raise_warning` is added in several classes to control the output of warnings when the number of bins is lower for at least one sample.