### PR TITLE
Fix a bug when all the subsequences have std below the threshold and remove constant sample check in KBinsDiscretizer

### DIFF
--- a/pyts/approximation/sax.py
+++ b/pyts/approximation/sax.py
@@ -104,10 +104,10 @@ class SymbolicAggregateApproximation(BaseEstimator,
     def _check_params(self, n_timestamps):
         if not isinstance(self.n_bins, (int, np.integer)):
             raise TypeError("'n_bins' must be an integer.")
-        if not 2 <= self.n_bins <= min(n_timestamps, 26):
+        if not 2 <= self.n_bins <= 26:
             raise ValueError(
                 "'n_bins' must be greater than or equal to 2 and lower than "
-                "or equal to min(n_timestamps, 26) (got {0})."
+                "or equal to 26 (got {0})."
                 .format(self.n_bins)
             )
         if self.strategy not in ['uniform', 'quantile', 'normal']:

--- a/pyts/approximation/tests/test_sax.py
+++ b/pyts/approximation/tests/test_sax.py
@@ -22,11 +22,11 @@ X = np.arange(30).reshape(3, 10)
 
      ({'n_bins': 1}, ValueError,
       "'n_bins' must be greater than or equal to 2 and lower than "
-      "or equal to min(n_timestamps, 26) (got 1)."),
+      "or equal to 26 (got 1)."),
 
-     ({'n_bins': 15}, ValueError,
+     ({'n_bins': 27}, ValueError,
       "'n_bins' must be greater than or equal to 2 and lower than "
-      "or equal to min(n_timestamps, 26) (got 15)."),
+      "or equal to 26 (got 27)."),
 
      ({'strategy': 'whoops'}, ValueError,
       "'strategy' must be either 'uniform', 'quantile' or 'normal' "

--- a/pyts/bag_of_words/bow.py
+++ b/pyts/bag_of_words/bow.py
@@ -430,10 +430,10 @@ class BagOfWords(BaseEstimator, TransformerMixin):
 
         if not isinstance(self.n_bins, (int, np.integer)):
             raise TypeError("'n_bins' must be an integer.")
-        if not 2 <= self.n_bins <= min(word_size, 26):
+        if not 2 <= self.n_bins <= 26:
             raise ValueError(
                 "'n_bins' must be greater than or equal to 2 and lower than "
-                "or equal to min(word_size, 26) (got {0})."
+                "or equal to 26 (got {0})."
                 .format(self.n_bins)
             )
 

--- a/pyts/bag_of_words/bow.py
+++ b/pyts/bag_of_words/bow.py
@@ -159,12 +159,12 @@ class BagOfWords(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    window_size : int, float or None (default = 0.5)
+    window_size : int or float (default = 0.5)
         Length of the sliding window. If float, it represents
         a percentage of the size of each time series and must be
         between 0 and 1.
 
-    word_size : int, float or None (default = 0.5)
+    word_size : int or float (default = 0.5)
         Length of the words. If float, it represents
         a percentage of the length of the sliding window and must be
         between 0. and 1.
@@ -189,10 +189,10 @@ class BagOfWords(BaseEstimator, TransformerMixin):
         the size of each time series and must be between 0 and 1. The window
         size will be computed as ``ceil(window_step * n_timestamps)``.
 
-    threshold_std: float (default = 0.01)
+    threshold_std: int, float or None (default = 0.01)
         Threshold used to determine whether a subsequence is standardized.
         Subsequences whose standard deviations are lower than this threshold
-        are not standardized.
+        are not standardized. If None, all the subsequences are standardized.
 
     norm_mean : bool (default = True)
         If True, center each subseries before scaling.
@@ -303,38 +303,40 @@ class BagOfWords(BaseEstimator, TransformerMixin):
             X_scaled, n_samples, n_timestamps, window_size, window_step
         ).reshape(n_samples * n_windows, window_size)
 
-        # Identify subsequences whose standard deviation is below the threshold
-        idx = np.std(X_window, axis=1) < self.threshold_std
+        if self.threshold_std is not None:
 
-        if np.any(idx):
-            # Subsequences with standard deviations below threshold
-            X_paa = PiecewiseAggregateApproximation(
-                window_size=None, output_size=word_size,
-                overlapping=self.overlapping
-            ).transform(X_window[idx])
+            # Identify subsequences whose standard deviation below threshold
+            idx = np.std(X_window, axis=1) < self.threshold_std
 
-            # Compute the bin edges
-            discretizer = KBinsDiscretizer(
-                n_bins=self.n_bins, strategy=self.strategy,
-                raise_warning=self.raise_warning
-            )
-            bin_edges = discretizer._compute_bins(X_scaled, n_samples,
-                                                  self.n_bins, self.strategy)
+            if np.any(idx):
+                # Subsequences with standard deviations below threshold
+                X_paa = PiecewiseAggregateApproximation(
+                    window_size=None, output_size=word_size,
+                    overlapping=self.overlapping
+                ).transform(X_window[idx])
 
-            # Tile the bin edges for each subsequence from the same time series
-            if self.strategy != 'normal':
-                count = np.bincount(
-                    np.floor_divide(np.nonzero(idx)[0], n_windows)
+                # Compute the bin edges
+                discretizer = KBinsDiscretizer(
+                    n_bins=self.n_bins, strategy=self.strategy,
+                    raise_warning=self.raise_warning
                 )
-                bin_edges = np.vstack([
-                    np.tile(bin_edges[i], (count[i], 1))
-                    for i in range(count.size) if count[i] != 0
-                ])
+                bin_edges = discretizer._compute_bins(
+                    X_scaled, n_samples, self.n_bins, self.strategy)
 
-            X_sax_below_thresh = alphabet[_digitize(X_paa, bin_edges)]
+                # Tile the bin edges for subsequences from the same time series
+                if self.strategy != 'normal':
+                    count = np.bincount(
+                        np.floor_divide(np.nonzero(idx)[0], n_windows)
+                    )
+                    bin_edges = np.vstack([
+                        np.tile(bin_edges[i], (count[i], 1))
+                        for i in range(count.size) if count[i] != 0
+                    ])
+
+                X_sax_below_thresh = alphabet[_digitize(X_paa, bin_edges)]
 
         # Subsequences with standard deviations above threshold
-        if not np.all(idx):
+        if (self.threshold_std is None) or (not np.all(idx)):
             pipeline = make_pipeline(
                 StandardScaler(
                     with_mean=self.norm_mean, with_std=self.norm_std
@@ -348,17 +350,23 @@ class BagOfWords(BaseEstimator, TransformerMixin):
                     alphabet=self.alphabet, raise_warning=self.raise_warning
                 )
             )
-            X_sax_above_thresh = pipeline.fit_transform(X_window[~idx])
+            if self.threshold_std is None:
+                X_sax_above_thresh = pipeline.fit_transform(X_window)
+            else:
+                X_sax_above_thresh = pipeline.fit_transform(X_window[~idx])
 
         # Concatenate SAX words
-        if np.any(idx):
-            if not np.all(idx):
-                X_sax = np.empty((n_samples * n_windows, word_size),
-                                 dtype='<U1')
-                X_sax[idx] = X_sax_below_thresh
-                X_sax[~idx] = X_sax_above_thresh
+        if self.threshold_std is not None:
+            if np.any(idx):
+                if not np.all(idx):
+                    X_sax = np.empty((n_samples * n_windows, word_size),
+                                     dtype='<U1')
+                    X_sax[idx] = X_sax_below_thresh
+                    X_sax[~idx] = X_sax_above_thresh
+                else:
+                    X_sax = X_sax_below_thresh
             else:
-                X_sax = X_sax_below_thresh
+                X_sax = X_sax_above_thresh
         else:
             X_sax = X_sax_above_thresh
         X_sax = X_sax.reshape(n_samples, n_windows, word_size)
@@ -453,11 +461,17 @@ class BagOfWords(BaseEstimator, TransformerMixin):
                 )
             window_step = ceil(self.window_step * n_timestamps)
 
-        if not isinstance(self.threshold_std, (float, np.floating)):
-            raise TypeError("'threshold_std' must be a float.")
-        if not self.threshold_std >= 0.:
-            raise ValueError("'threshold_std' must be non-negative "
-                             "(got {0}).".format(self.threshold_std))
+        threshold_std_none = self.threshold_std is None
+        threshold_std_int_float = isinstance(
+            self.threshold_std, (int, np.integer, float, np.floating))
+        if not (threshold_std_none or threshold_std_int_float):
+            raise TypeError(
+                "'threshold_std' must be an integer, a float or None."
+            )
+        if threshold_std_int_float and (not self.threshold_std >= 0.):
+            raise ValueError("If 'threshold_std' is an integer or a float, it "
+                             "must be non-negative (got {0})."
+                             .format(self.threshold_std))
 
         if not ((self.alphabet is None)
                 or (isinstance(self.alphabet, (list, tuple, np.ndarray)))):

--- a/pyts/bag_of_words/tests/test_bow.py
+++ b/pyts/bag_of_words/tests/test_bow.py
@@ -162,6 +162,22 @@ def test_parameter_check_bag_of_words(params, error, err_msg):
      ({'window_size': 8, 'word_size': 4, 'strategy': 'quantile'}, X_bow,
       ['abcd', 'abcd', 'aaaa aaac']),
 
+     ({'window_size': 8, 'word_size': 4, 'strategy': 'uniform',
+       'threshold_std': np.inf}, X_bow,
+      ['abbc abcd bbcd', 'abbc abcd bbcd', 'aaaa aaab aaad']),
+
+     ({'window_size': 8, 'word_size': 4, 'strategy': 'quantile',
+       'threshold_std': np.inf}, X_bow,
+      ['abbc abcd bbcd', 'abbc abcd bbcd', 'aaaa aaab']),
+
+     ({'window_size': 8, 'word_size': 4, 'strategy': 'uniform',
+       'threshold_std': 2.4}, X_bow,
+      ['abbc abcd bbcd', 'abbc abcd bbcd', 'aaaa aaad']),
+
+     ({'window_size': 8, 'word_size': 4, 'strategy': 'quantile',
+       'threshold_std': 2.4}, X_bow,
+      ['abbc abcd bbcd', 'abbc abcd bbcd', 'aaaa aaac']),
+
      ({'window_size': 8, 'word_size': 4, 'alphabet': ['y', 'o', 'l', 'o']},
       X_bow, ['yolo', 'yolo', 'oooo']),
 

--- a/pyts/bag_of_words/tests/test_bow.py
+++ b/pyts/bag_of_words/tests/test_bow.py
@@ -124,13 +124,14 @@ X_bow[2, :8] = 20
       "If 'window_step' is a float, it must be greater than 0 and lower "
       "than or equal to 1 (got {0}).".format(2.)),
 
-     ({'window_size': 6, 'word_size': 4, 'n_bins': 2, 'threshold_std': '-1'},
+     ({'window_size': 6, 'word_size': 4, 'n_bins': 2, 'threshold_std': '[-1]'},
       TypeError,
-      "'threshold_std' must be a float."),
+      "'threshold_std' must be an integer, a float or None."),
 
      ({'window_size': 6, 'word_size': 4, 'n_bins': 2, 'threshold_std': -1.},
       ValueError,
-      "'threshold_std' must be non-negative (got -1.0)."),
+      "If 'threshold_std' is an integer or a float, it must be non-negative "
+      "(got -1.0)."),
 
      ({'window_size': 6, 'word_size': 4, 'n_bins': 2, 'alphabet': 'whoops'},
       TypeError,
@@ -169,6 +170,14 @@ def test_parameter_check_bag_of_words(params, error, err_msg):
      ({'window_size': 8, 'word_size': 4, 'strategy': 'quantile',
        'threshold_std': np.inf}, X_bow,
       ['abbc abcd bbcd', 'abbc abcd bbcd', 'aaaa aaab']),
+
+     ({'window_size': 8, 'word_size': 4, 'strategy': 'uniform',
+       'threshold_std': None}, X_bow,
+      ['abcd', 'abcd', 'aaaa aaad']),
+
+     ({'window_size': 8, 'word_size': 4, 'strategy': 'quantile',
+       'threshold_std': None}, X_bow,
+      ['abcd', 'abcd', 'aaaa aaac']),
 
      ({'window_size': 8, 'word_size': 4, 'strategy': 'uniform',
        'threshold_std': 2.4}, X_bow,

--- a/pyts/bag_of_words/tests/test_bow.py
+++ b/pyts/bag_of_words/tests/test_bow.py
@@ -103,7 +103,11 @@ X_bow[2, :8] = 20
 
      ({'n_bins': 1}, ValueError,
       "'n_bins' must be greater than or equal to 2 and lower than "
-      "or equal to min(word_size, 26) (got 1)."),
+      "or equal to 26 (got 1)."),
+
+     ({'n_bins': 27}, ValueError,
+      "'n_bins' must be greater than or equal to 2 and lower than "
+      "or equal to 26 (got 27)."),
 
      ({'window_size': 6, 'word_size': 4, 'n_bins': 2, 'strategy': 'whoops'},
       ValueError,

--- a/pyts/preprocessing/discretizer.py
+++ b/pyts/preprocessing/discretizer.py
@@ -129,7 +129,6 @@ class KBinsDiscretizer(BaseEstimator, UnivariateTransformerMixin):
         X = check_array(X, dtype='float64')
         n_samples, n_timestamps = X.shape
         self._check_params(n_timestamps)
-        self._check_constant(X)
 
         bin_edges = self._compute_bins(
             X, n_samples, self.n_bins, self.strategy)
@@ -139,18 +138,14 @@ class KBinsDiscretizer(BaseEstimator, UnivariateTransformerMixin):
     def _check_params(self, n_timestamps):
         if not isinstance(self.n_bins, (int, np.integer)):
             raise TypeError("'n_bins' must be an integer.")
-        if not 2 <= self.n_bins <= n_timestamps:
+        if not 2 <= self.n_bins:
             raise ValueError(
-                "'n_bins' must be greater than or equal to 2 and lower than "
-                "or equal to n_timestamps (got {0}).".format(self.n_bins)
+                "'n_bins' must be greater than or equal to 2 (got {0})."
+                .format(self.n_bins)
             )
         if self.strategy not in ['uniform', 'quantile', 'normal']:
             raise ValueError("'strategy' must be either 'uniform', 'quantile' "
                              "or 'normal' (got {0}).".format(self.strategy))
-
-    def _check_constant(self, X):
-        if np.any(np.max(X, axis=1) - np.min(X, axis=1) == 0):
-            raise ValueError("At least one sample is constant.")
 
     def _compute_bins(self, X, n_samples, n_bins, strategy):
         if strategy == 'normal':

--- a/pyts/preprocessing/tests/test_discretizer.py
+++ b/pyts/preprocessing/tests/test_discretizer.py
@@ -70,12 +70,10 @@ def test_reshape_with_nan(params, arr_desired):
     [({'n_bins': None}, TypeError, "'n_bins' must be an integer."),
 
      ({'n_bins': 1}, ValueError,
-      "'n_bins' must be greater than or equal to 2 and lower than "
-      "or equal to n_timestamps (got 1)."),
+      "'n_bins' must be greater than or equal to 2 (got 1)."),
 
-     ({'n_bins': n_timestamps + 1}, ValueError,
-      "'n_bins' must be greater than or equal to 2 and lower than "
-      "or equal to n_timestamps (got {0}).".format(n_timestamps + 1)),
+     ({'n_bins': 0}, ValueError,
+      "'n_bins' must be greater than or equal to 2 (got 0)."),
 
      ({'strategy': 'whoops'}, ValueError,
       "'strategy' must be either 'uniform', 'quantile' or 'normal' (got {0})."
@@ -86,13 +84,6 @@ def test_parameter_check(params, error, err_msg):
     discretizer = KBinsDiscretizer(**params)
     with pytest.raises(error, match=re.escape(err_msg)):
         discretizer.transform(X)
-
-
-def test_constant_sample():
-    """Test that a ValueError is raised with a constant sample."""
-    discretizer = KBinsDiscretizer()
-    with pytest.raises(ValueError, match="At least one sample is constant."):
-        discretizer.fit_transform(np.ones((10, 15)))
 
 
 def test_warning_smaller_n_bins():


### PR DESCRIPTION
* An error is currently raised when all the subsequences have a standard deviation below `threshold_std` because the pipeline for the subsequences whose standard deviation is above `threshold` is still run with 0 samples. This PR fixes this bug.
* The constant sample check is removed in KBinsDiscretizer.
* The maximum number of bins is set to 26 for SAX and BagOfWords and no maximum limit is fixed in KBinsDiscretizer.