### PR TITLE
add `n_init` argument to KMeans to supress warning

### DIFF
--- a/pyts/classification/learning_shapelets.py
+++ b/pyts/classification/learning_shapelets.py
@@ -472,7 +472,7 @@ class CrossEntropyLearningShapelets(BaseEstimator, UnivariateClassifierMixin):
             X_window = _windowed_view(
                 X, n_samples, n_timestamps, window_size, window_step=1)
             X_window = X_window.reshape(-1, window_size)
-            kmeans = KMeans(n_clusters=n_shapelets_per_size, random_state=rng)
+            kmeans = KMeans(n_clusters=n_shapelets_per_size, random_state=rng, n_init=10)
             kmeans.fit(X_window)
             shapelets.append(kmeans.cluster_centers_)
             lengths.append(np.full(n_shapelets_per_size, window_size))


### PR DESCRIPTION
Preserve the same behaviour, but add the `n_init` argument to the sklearn KMeans function to [prevent this warning](https://github.com/scikit-learn/scikit-learn/blob/7db5b6a98/sklearn/cluster/_kmeans.py#L870).