### PR TITLE
Add packaging requirement and properly compare scipy version

### DIFF
--- a/doc/pytsdtwdoc.py
+++ b/doc/pytsdtwdoc.py
@@ -29,7 +29,7 @@ import pydoc
 import inspect
 import textwrap
 import warnings
-
+from packaging.version import parse
 
 from numpydoc.numpydoc import mangle_docstrings
 from docutils.statemachine import ViewList
@@ -37,7 +37,7 @@ from sphinx.domains.python import PythonDomain
 
 import scipy
 SCIPY_VERSION = scipy.__version__
-if SCIPY_VERSION < '1.5':
+if parse(SCIPY_VERSION) < parse('1.5'):
     from scipy._lib._util import getargspec_no_self
 else:
     from scipy._lib._util import getfullargspec_no_self

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ EXTRAS_REQUIRE = {
         'sphinx==1.8.5',
         'sphinx-gallery',
         'numpydoc',
-        'matplotlib'
+        'matplotlib',
+        'packaging'
     ]
 }
 PACKAGE_DATA = {


### PR DESCRIPTION
This PR adds packaging as an extra requirement to build the documentation and updates the comparison of scipy version using packaging.version.parse.